### PR TITLE
Replace Y_SWEET env variables

### DIFF
--- a/crates/entrypoint.sh
+++ b/crates/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 set -e  # Exit on error
 
-# If Y_SWEET_URL_PREFIX is not set but FLY_APP_NAME is, construct the URL
-if [ -z "$Y_SWEET_URL_PREFIX" ] && [ -n "$FLY_APP_NAME" ]; then
-    export Y_SWEET_URL_PREFIX="https://$FLY_APP_NAME.fly.dev"
-    echo "🪽  Running on fly.io. Setting --url-prefix=$Y_SWEET_URL_PREFIX"
+# Backwards compatibility for deprecated Y_SWEET_ variables
+if [ -z "$RELAY_URL_PREFIX" ] && [ -n "$Y_SWEET_URL_PREFIX" ]; then
+    echo "⚠️  Y_SWEET_URL_PREFIX is deprecated. Please use RELAY_URL_PREFIX" >&2
+    export RELAY_URL_PREFIX="$Y_SWEET_URL_PREFIX"
+fi
+
+# If RELAY_URL_PREFIX is not set but FLY_APP_NAME is, construct the URL
+if [ -z "$RELAY_URL_PREFIX" ] && [ -n "$FLY_APP_NAME" ]; then
+    export RELAY_URL_PREFIX="https://$FLY_APP_NAME.fly.dev"
+    echo "🪽  Running on fly.io. Setting --url-prefix=$RELAY_URL_PREFIX"
 fi
 
 if [ -n "$TAILSCALE_AUTHKEY" ]; then

--- a/crates/run.sh
+++ b/crates/run.sh
@@ -4,17 +4,27 @@ set -e  # Exit on error
 # Handle signals properly
 trap "exit" TERM INT
 
-# If Y_SWEET_URL_PREFIX is not set but FLY_APP_NAME is, construct the URL
-if [ -z "$Y_SWEET_URL_PREFIX" ] && [ -n "$FLY_APP_NAME" ]; then
-    export Y_SWEET_URL_PREFIX="https://$FLY_APP_NAME.fly.dev"
-    echo "🪽  Running on fly.io. Setting --url-prefix=$Y_SWEET_URL_PREFIX"
+# Backwards compatibility for deprecated Y_SWEET_ variables
+if [ -z "$RELAY_URL_PREFIX" ] && [ -n "$Y_SWEET_URL_PREFIX" ]; then
+    echo "⚠️  Y_SWEET_URL_PREFIX is deprecated. Please use RELAY_URL_PREFIX" >&2
+    export RELAY_URL_PREFIX="$Y_SWEET_URL_PREFIX"
+fi
+if [ -z "$RELAY_STORE" ] && [ -n "$Y_SWEET_STORE" ]; then
+    echo "⚠️  Y_SWEET_STORE is deprecated. Please use RELAY_STORE" >&2
+    export RELAY_STORE="$Y_SWEET_STORE"
 fi
 
-# If Y_SWEET_STORE is not set, default to local /data
-if [ -z "$Y_SWEET_STORE" ]; then
-    export Y_SWEET_STORE=/data
+# If RELAY_URL_PREFIX is not set but FLY_APP_NAME is, construct the URL
+if [ -z "$RELAY_URL_PREFIX" ] && [ -n "$FLY_APP_NAME" ]; then
+    export RELAY_URL_PREFIX="https://$FLY_APP_NAME.fly.dev"
+    echo "🪽  Running on fly.io. Setting --url-prefix=$RELAY_URL_PREFIX"
 fi
-echo "💾 Persisting data to $Y_SWEET_STORE"
+
+# If RELAY_STORE is not set, default to local /data
+if [ -z "$RELAY_STORE" ]; then
+    export RELAY_STORE=/data
+fi
+echo "💾 Persisting data to $RELAY_STORE"
 
 if [ -n "$TAILSCALE_AUTHKEY" ]; then
     echo "🔑 Joining tailnet..."

--- a/crates/test_presign.py
+++ b/crates/test_presign.py
@@ -9,22 +9,22 @@ This script demonstrates how to:
 4. Verify the upload was successful
 
 Required environment variables:
-- Y_SWEET_AUTH - Authentication key for y-sweet
+- RELAY_AUTH - Authentication key for y-sweet
 - AWS_ACCESS_KEY_ID - S3 access key ID
 - AWS_SECRET_ACCESS_KEY - S3 secret access key
 - STORAGE_BUCKET - S3 bucket name (replaces AWS_S3_BUCKET)
 - AWS_REGION - S3 region (optional, defaults to us-east-1)
 - AWS_ENDPOINT_URL - S3 endpoint URL (optional)
-- Y_SWEET_STORE - Storage URL with optional prefix path (optional)
+- RELAY_STORE - Storage URL with optional prefix path (optional)
 
 Usage:
-    export Y_SWEET_AUTH="your-auth-key"
+    export RELAY_AUTH="your-auth-key"
     export AWS_ACCESS_KEY_ID="your-access-key"
     export AWS_SECRET_ACCESS_KEY="your-secret-key"
     export STORAGE_BUCKET="your-bucket"
     export AWS_REGION="your-region"  # Optional
     export AWS_ENDPOINT_URL="your-endpoint"  # Optional
-    export Y_SWEET_STORE="s3://your-bucket/optional-prefix"  # Optional
+    export RELAY_STORE="s3://your-bucket/optional-prefix"  # Optional
     ./test_presign.py
 """
 
@@ -62,7 +62,7 @@ def redact_url(url):
 def print_env_vars():
     """Print relevant environment variables (with secrets redacted)."""
     env_vars = {
-        "Y_SWEET_AUTH": "REDACTED" if "Y_SWEET_AUTH" in os.environ else "Not set",
+        "RELAY_AUTH": "REDACTED" if "RELAY_AUTH" in os.environ else "Not set",
         "AWS_ACCESS_KEY_ID": "REDACTED" if "AWS_ACCESS_KEY_ID" in os.environ else "Not set",
         "AWS_SECRET_ACCESS_KEY": "REDACTED" if "AWS_SECRET_ACCESS_KEY" in os.environ else "Not set",
         "STORAGE_BUCKET": os.environ.get("STORAGE_BUCKET", "Not set"),
@@ -72,7 +72,7 @@ def print_env_vars():
         "AWS_SESSION_TOKEN": "REDACTED" if "AWS_SESSION_TOKEN" in os.environ else "Not set",
         "AWS_S3_BUCKET_PREFIX": os.environ.get("AWS_S3_BUCKET_PREFIX", "Not set"),
         "AWS_S3_USE_PATH_STYLE": os.environ.get("AWS_S3_USE_PATH_STYLE", "Not set"),
-        "Y_SWEET_STORE": os.environ.get("Y_SWEET_STORE", "Not set"),
+        "RELAY_STORE": os.environ.get("RELAY_STORE", "Not set"),
     }
     
     log("Environment variables:")
@@ -212,10 +212,10 @@ def main():
     log("Starting test_presign.py script")
     print_env_vars()
     
-    # Check if Y_SWEET_STORE is set and has a prefix
-    y_sweet_store = os.environ.get("Y_SWEET_STORE", "")
+    # Check if RELAY_STORE is set and has a prefix
+    y_sweet_store = os.environ.get("RELAY_STORE", "")
     if y_sweet_store:
-        log(f"Y_SWEET_STORE is set to: {y_sweet_store}")
+        log(f"RELAY_STORE is set to: {y_sweet_store}")
         # Parse the URL to extract prefix
         try:
             # Parse s3:// URL format
@@ -225,7 +225,7 @@ def main():
                 prefix = parts[1] if len(parts) > 1 else ""
                 log(f"Extracted bucket: {bucket}, prefix: {prefix}")
                 
-                # IMPORTANT: Y-SIGN USES AWS_S3_BUCKET_PREFIX NOT Y_SWEET_STORE
+                # IMPORTANT: Y-SIGN USES AWS_S3_BUCKET_PREFIX NOT RELAY_STORE
                 # Need to set AWS_S3_BUCKET_PREFIX for y-sign to use the prefix
                 if prefix:
                     os.environ["AWS_S3_BUCKET_PREFIX"] = prefix
@@ -237,7 +237,7 @@ def main():
                         log(f"WARNING: Your prefix ends with a slash, which may cause double slashes in URLs: '{prefix}'", "WARNING")
                         log(f"This can result in the pattern '{prefix}/files/' becoming '{prefix}//files/' in paths")
         except Exception as e:
-            log(f"Error parsing Y_SWEET_STORE: {str(e)}", "ERROR")
+            log(f"Error parsing RELAY_STORE: {str(e)}", "ERROR")
     
     # Create a test file
     test_content = "Hello, world! This is a test file."
@@ -256,7 +256,7 @@ def main():
     
     log("Step 1: Generating file token")
     token_result = run_y_sign(
-        ["sign", "--auth", os.environ.get("Y_SWEET_AUTH", "")], 
+        ["sign", "--auth", os.environ.get("RELAY_AUTH", "")], 
         token_data,
         "token generation"
     )
@@ -270,7 +270,7 @@ def main():
     # Step 2: Generate a presigned upload URL using the token
     log("Step 2: Generating presigned upload URL")
     upload_result = run_y_sign(
-        ["presign", "upload-url", "--auth", os.environ.get("Y_SWEET_AUTH", "")], 
+        ["presign", "upload-url", "--auth", os.environ.get("RELAY_AUTH", "")], 
         token,
         "upload URL generation"
     )
@@ -302,7 +302,7 @@ def main():
         else:
             log(f"  {key}: {values[0]}", "DEBUG")
     
-    # Check if the URL path contains the expected prefix if Y_SWEET_STORE was set with a prefix
+    # Check if the URL path contains the expected prefix if RELAY_STORE was set with a prefix
     path_match = True
     if y_sweet_store and '/' in y_sweet_store[5:]:
         _, prefix = y_sweet_store[5:].split('/', 1)
@@ -320,7 +320,7 @@ def main():
             log(f"- Expected pattern: {expected_pattern}", "DEBUG")
             log(f"- File hash: {file_hash}", "DEBUG")
             log(f"- Complete URL (redacted): {redact_url(upload_url)}", "DEBUG")
-            log(f"- Environment - Y_SWEET_STORE: {y_sweet_store}", "DEBUG")
+            log(f"- Environment - RELAY_STORE: {y_sweet_store}", "DEBUG")
             
             # Proceed with the actual check
             if expected_pattern in url_parts.path:
@@ -330,12 +330,12 @@ def main():
                 # Also check if the path has "files/" without the prefix - this is still wrong
                 if "/files/" in url_parts.path or f"/{file_hash}" in url_parts.path:
                     log(f"ERROR: URL contains 'files/' but missing prefix '{prefix}'. Path: {url_parts.path}", "ERROR")
-                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check Y_SWEET_STORE setting.", "ERROR")
+                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check RELAY_STORE setting.", "ERROR")
                     # Continue execution for debug purpose instead of exiting
                     path_match = False  # Mark as failed but continue for debugging
                 else:
                     log(f"ERROR: URL does not contain expected prefix path '{expected_pattern}' in: {url_parts.path}", "ERROR")
-                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check Y_SWEET_STORE setting.", "ERROR")
+                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check RELAY_STORE setting.", "ERROR")
                     # Continue execution for debug purpose instead of exiting
                     path_match = False  # Mark as failed but continue for debugging
     
@@ -435,7 +435,7 @@ def main():
     # Step 4: Generate a download URL for verification
     log("Step 4: Generating presigned download URL")
     download_result = run_y_sign(
-        ["presign", "download-url", "--auth", os.environ.get("Y_SWEET_AUTH", "")], 
+        ["presign", "download-url", "--auth", os.environ.get("RELAY_AUTH", "")], 
         token,
         "download URL generation"
     )
@@ -474,12 +474,12 @@ def main():
                 # Also check if the path has "files/" without the prefix - this is still wrong
                 if "/files/" in download_url_parts.path or f"/{file_hash}" in download_url_parts.path:
                     log(f"ERROR: Download URL contains 'files/' but missing prefix '{prefix}'. Path: {download_url_parts.path}", "ERROR")
-                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check Y_SWEET_STORE setting.", "ERROR")
+                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check RELAY_STORE setting.", "ERROR")
                     # Continue execution for debug purpose instead of exiting
                     path_match = False  # Mark as failed but continue for debugging
                 else:
                     log(f"ERROR: Download URL does not contain expected prefix path '{expected_pattern}' in: {download_url_parts.path}", "ERROR")
-                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check Y_SWEET_STORE setting.", "ERROR")
+                    log(f"The bucket prefix '{prefix}' is not being correctly applied to the URL. Check RELAY_STORE setting.", "ERROR")
                     # Continue execution for debug purpose instead of exiting
                     path_match = False  # Mark as failed but continue for debugging
     

--- a/crates/y-sign/src/main.rs
+++ b/crates/y-sign/src/main.rs
@@ -608,14 +608,14 @@ enum SignSubcommand {
     /// Generate a token for a document or file
     Sign {
         /// The authentication key for signing tokens
-        #[clap(long, env = "Y_SWEET_AUTH")]
+        #[clap(long, env = "RELAY_AUTH")]
         auth: String,
     },
 
     /// Verify a token for a document or file
     Verify {
         /// The authentication key for verifying tokens
-        #[clap(long, env = "Y_SWEET_AUTH")]
+        #[clap(long, env = "RELAY_AUTH")]
         auth: String,
 
         /// The document ID to verify against
@@ -633,7 +633,7 @@ enum SignSubcommand {
         action: String,
 
         /// Optional S3 store URL (s3://bucket/path format)
-        #[clap(long, env = "Y_SWEET_STORE")]
+        #[clap(long, env = "RELAY_STORE")]
         store: Option<String>,
 
         /// Optional AWS endpoint URL override
@@ -645,7 +645,7 @@ enum SignSubcommand {
         path_style: bool,
 
         /// The authentication key for validating tokens
-        #[clap(long, env = "Y_SWEET_AUTH")]
+        #[clap(long, env = "RELAY_AUTH")]
         auth: Option<String>,
     },
 
@@ -683,7 +683,7 @@ async fn main() -> Result<()> {
         } => {
             // If store is provided via CLI arg, set it as an environment variable
             if let Some(store_url) = store {
-                std::env::set_var("Y_SWEET_STORE", store_url);
+                std::env::set_var("RELAY_STORE", store_url);
             }
 
             // Use the unified S3Config::from_env method
@@ -702,8 +702,8 @@ async fn main() -> Result<()> {
             // Get auth key from command line argument or environment
             let auth_key = match auth {
                 Some(key) => key.clone(),
-                None => std::env::var("Y_SWEET_AUTH").map_err(|_| {
-                    anyhow::anyhow!("Y_SWEET_AUTH environment variable is required")
+                None => std::env::var("RELAY_AUTH").map_err(|_| {
+                    anyhow::anyhow!("RELAY_AUTH environment variable is required")
                 })?,
             };
             let authenticator = Authenticator::new(&auth_key)?;

--- a/crates/y-sweet-core/src/store/s3.rs
+++ b/crates/y-sweet-core/src/store/s3.rs
@@ -38,8 +38,8 @@ impl S3Config {
     ///
     /// This is the unified configuration parser used by both y-sweet and y-sign
     pub fn from_env(bucket: Option<String>, prefix: Option<String>) -> anyhow::Result<Self> {
-        // First check for Y_SWEET_STORE which has highest precedence
-        if let Ok(store_path) = env::var("Y_SWEET_STORE") {
+        // First check for RELAY_STORE which has highest precedence
+        if let Ok(store_path) = env::var("RELAY_STORE") {
             if store_path.starts_with("s3://") {
                 // Parse the S3 URL to extract bucket and prefix
                 let url = UrlParser::parse(&store_path)?;
@@ -62,7 +62,7 @@ impl S3Config {
 
         // Otherwise, look for STORAGE_BUCKET or AWS_S3_BUCKET
         let bucket = env::var("STORAGE_BUCKET").or_else(|_| env::var("AWS_S3_BUCKET"))
-            .map_err(|_| anyhow::anyhow!("Either Y_SWEET_STORE (s3:// URL) or STORAGE_BUCKET/AWS_S3_BUCKET environment variable is required"))?;
+            .map_err(|_| anyhow::anyhow!("Either RELAY_STORE (s3:// URL) or STORAGE_BUCKET/AWS_S3_BUCKET environment variable is required"))?;
 
         // Use STORAGE_PREFIX for consistency with both tools
         let bucket_prefix = env::var("STORAGE_PREFIX")

--- a/crates/y-sweet-worker/src/config.rs
+++ b/crates/y-sweet-worker/src/config.rs
@@ -4,7 +4,7 @@ use worker::Env;
 use y_sweet_core::auth::KeyId;
 use y_sweet_core::store::s3::S3Config;
 
-const BUCKET: &str = "Y_SWEET_DATA";
+const BUCKET: &str = "RELAY_DATA";
 const BUCKET_KIND: &str = "BUCKET_KIND";
 const AUTH_KEY: &str = "AUTH_KEY";
 const S3_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";

--- a/crates/y-sweet-worker/wrangler.toml
+++ b/crates/y-sweet-worker/wrangler.toml
@@ -13,7 +13,7 @@ tag = "v1"
 new_classes = ["YServe"]
 
 [[r2_buckets]]
-binding = "Y_SWEET_DATA"
+binding = "RELAY_DATA"
 bucket_name = "y-sweet-data"
 preview_bucket_name = "y-sweet-data-dev"
 
@@ -31,7 +31,7 @@ bindings = [
 ]
 
 [[env.staging.r2_buckets]]
-binding = "Y_SWEET_DATA"
+binding = "RELAY_DATA"
 bucket_name = "y-sweet-data-staging"
 preview_bucket_name = "y-sweet-data-dev"
 
@@ -44,6 +44,6 @@ bindings = [
 ]
 
 [[env.test.r2_buckets]]
-binding = "Y_SWEET_DATA"
+binding = "RELAY_DATA"
 bucket_name = "y-sweet-data-staging"
 preview_bucket_name = "y-sweet-data-dev"

--- a/crates/y-sweet/src/cli.rs
+++ b/crates/y-sweet/src/cli.rs
@@ -160,7 +160,7 @@ pub async fn sign_stdin(auth: &Authenticator) -> anyhow::Result<()> {
 
             let token = auth.gen_doc_token(&doc_id, authorization.clone(), expiration);
 
-            let (url, base_url) = if let Ok(prefix_url) = std::env::var("Y_SWEET_PREFIX_URL") {
+            let (url, base_url) = if let Ok(prefix_url) = std::env::var("RELAY_PREFIX_URL") {
                 let prefix_url = Url::parse(&prefix_url)?;
                 let mut ws_url = prefix_url.clone();
                 ws_url

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -34,20 +34,20 @@ struct Opts {
 #[derive(Subcommand)]
 enum ServSubcommand {
     Serve {
-        #[clap(env = "Y_SWEET_STORE")]
+        #[clap(env = "RELAY_STORE")]
         store: Option<String>,
 
         #[clap(long, default_value = "8080", env = "PORT")]
         port: u16,
-        #[clap(long, env = "Y_SWEET_HOST")]
+        #[clap(long, env = "RELAY_HOST")]
         host: Option<IpAddr>,
-        #[clap(long, default_value = "10", env = "Y_SWEET_CHECKPOINT_FREQ_SECONDS")]
+        #[clap(long, default_value = "10", env = "RELAY_CHECKPOINT_FREQ_SECONDS")]
         checkpoint_freq_seconds: u64,
 
-        #[clap(long, env = "Y_SWEET_AUTH")]
+        #[clap(long, env = "RELAY_AUTH")]
         auth: Option<String>,
 
-        #[clap(long, env = "Y_SWEET_URL_PREFIX")]
+        #[clap(long, env = "RELAY_URL_PREFIX")]
         url_prefix: Option<Url>,
 
         #[clap(long)]
@@ -63,7 +63,7 @@ enum ServSubcommand {
     /// The YDoc update should be passed in via stdin.
     ConvertFromUpdate {
         /// The store to write the document to.
-        #[clap(env = "Y_SWEET_STORE")]
+        #[clap(env = "RELAY_STORE")]
         store: String,
 
         /// The ID of the document to write.
@@ -76,20 +76,20 @@ enum ServSubcommand {
         #[clap(long, default_value = "8080", env = "PORT")]
         port: u16,
 
-        #[clap(long, env = "Y_SWEET_HOST")]
+        #[clap(long, env = "RELAY_HOST")]
         host: Option<IpAddr>,
 
-        #[clap(long, default_value = "10", env = "Y_SWEET_CHECKPOINT_FREQ_SECONDS")]
+        #[clap(long, default_value = "10", env = "RELAY_CHECKPOINT_FREQ_SECONDS")]
         checkpoint_freq_seconds: u64,
     },
 
     Sign {
-        #[clap(long, env = "Y_SWEET_AUTH")]
+        #[clap(long, env = "RELAY_AUTH")]
         auth: String,
     },
 
     Verify {
-        #[clap(long, env = "Y_SWEET_AUTH")]
+        #[clap(long, env = "RELAY_AUTH")]
         auth: String,
 
         #[clap(long)]
@@ -102,8 +102,8 @@ enum ServSubcommand {
 
 fn get_store_from_opts(store_path: &str) -> Result<Box<dyn Store>> {
     if store_path.starts_with("s3://") {
-        // Set the Y_SWEET_STORE environment variable so S3Config::from_env can use it
-        env::set_var("Y_SWEET_STORE", store_path);
+        // Set the RELAY_STORE environment variable so S3Config::from_env can use it
+        env::set_var("RELAY_STORE", store_path);
 
         // Use the unified S3Config::from_env method
         let config = S3Config::from_env(None, None)?;

--- a/python/examples/file_presign_example.py
+++ b/python/examples/file_presign_example.py
@@ -31,17 +31,17 @@ def main():
     Demonstrate file presign functionality of the y_sign module.
     """
     # Get the auth key from environment variable
-    auth_key = os.environ.get("Y_SWEET_AUTH")
+    auth_key = os.environ.get("RELAY_AUTH")
     if not auth_key:
-        print("Error: Y_SWEET_AUTH environment variable is required.", file=sys.stderr)
+        print("Error: RELAY_AUTH environment variable is required.", file=sys.stderr)
         return 1
     
     # Check if S3 environment variables are set
     if not os.environ.get("AWS_ACCESS_KEY_ID") or not os.environ.get("AWS_SECRET_ACCESS_KEY"):
         print("Warning: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY should be set for S3 operations.")
     
-    if not os.environ.get("STORAGE_BUCKET") and not os.environ.get("Y_SWEET_STORE"):
-        print("Warning: STORAGE_BUCKET or Y_SWEET_STORE should be set for S3 operations.")
+    if not os.environ.get("STORAGE_BUCKET") and not os.environ.get("RELAY_STORE"):
+        print("Warning: STORAGE_BUCKET or RELAY_STORE should be set for S3 operations.")
     
     try:
         # Initialize the token generator

--- a/python/examples/y_sign_example.py
+++ b/python/examples/y_sign_example.py
@@ -13,7 +13,7 @@ def main():
     Demonstrate basic usage of the y_sign module.
     """
     # Get the auth key from environment variable or use a default for demo
-    auth_key = os.environ.get("Y_SWEET_AUTH", "replace_with_your_auth_key")
+    auth_key = os.environ.get("RELAY_AUTH", "replace_with_your_auth_key")
     
     # You can specify a custom path to the y-sign binary if needed
     # binary_path = "/path/to/y-sign"

--- a/python/tests/server.py
+++ b/python/tests/server.py
@@ -26,7 +26,7 @@ class Server:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=BASE_DIR,
-            env={"Y_SWEET_LOG_JSON": "true", **environ},
+            env={"RELAY_LOG_JSON": "true", **environ},
             text=True,
             bufsize=1,
         )

--- a/python/y-sign-py/examples/token_example.py
+++ b/python/y-sign-py/examples/token_example.py
@@ -13,7 +13,7 @@ def main():
     Demonstrate basic usage of the y_sign module with native Python bindings.
     """
     # Get the auth key from environment variable or use a default for demo
-    auth_key = os.environ.get("Y_SWEET_AUTH", "replace_with_your_auth_key")
+    auth_key = os.environ.get("RELAY_AUTH", "replace_with_your_auth_key")
     
     try:
         # Initialize the token generator

--- a/python/y-sign-py/test_binding.py
+++ b/python/y-sign-py/test_binding.py
@@ -3,9 +3,9 @@ import os
 import json
 
 # Get the auth key from environment
-auth_key = os.environ.get("Y_SWEET_AUTH")
+auth_key = os.environ.get("RELAY_AUTH")
 if not auth_key:
-    print("Please set Y_SWEET_AUTH environment variable")
+    print("Please set RELAY_AUTH environment variable")
     exit(1)
 
 print(f"Testing y_sign module with auth key: {auth_key}")

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,8 +16,8 @@ The test currently builds and tests three versions of the server:
 If _ALL FIVE_ of the following env vars are set, tests
 with S3 as the storage backend will also be run.
 
-- Y_SWEET_S3_ACCESS_KEY_ID
-- Y_SWEET_S3_SECRET_KEY
-- Y_SWEET_S3_REGION
-- Y_SWEET_S3_BUCKET_PREFIX
-- Y_SWEET_S3_BUCKET_NAME
+- RELAY_S3_ACCESS_KEY_ID
+- RELAY_S3_SECRET_KEY
+- RELAY_S3_REGION
+- RELAY_S3_BUCKET_PREFIX
+- RELAY_S3_BUCKET_NAME

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -30,11 +30,11 @@ function createYjsProvider(
 
 const CONFIGURATIONS: ServerConfiguration[] = [{ useAuth: false }, { useAuth: true }]
 
-let S3_ACCESS_KEY_ID = process.env.Y_SWEET_S3_ACCESS_KEY_ID
-let S3_SECRET_KEY = process.env.Y_SWEET_S3_SECRET_KEY
-let S3_REGION = process.env.Y_SWEET_S3_REGION
-let S3_BUCKET_PREFIX = process.env.Y_SWEET_S3_BUCKET_PREFIX
-let S3_BUCKET_NAME = process.env.Y_SWEET_S3_BUCKET_NAME
+let S3_ACCESS_KEY_ID = process.env.RELAY_S3_ACCESS_KEY_ID
+let S3_SECRET_KEY = process.env.RELAY_S3_SECRET_KEY
+let S3_REGION = process.env.RELAY_S3_REGION
+let S3_BUCKET_PREFIX = process.env.RELAY_S3_BUCKET_PREFIX
+let S3_BUCKET_NAME = process.env.RELAY_S3_BUCKET_NAME
 //run s3 tests if env vars set
 if (S3_ACCESS_KEY_ID && S3_REGION && S3_SECRET_KEY && S3_BUCKET_PREFIX && S3_BUCKET_NAME) {
   CONFIGURATIONS.push({

--- a/tests/test-with-minio.sh
+++ b/tests/test-with-minio.sh
@@ -22,9 +22,9 @@ docker exec minio-mc mc \
 docker exec minio-mc mc \
   mb mycloud/ysweet-testing-y-sweet-data
 
-export Y_SWEET_S3_BUCKET_PREFIX=testing
-export Y_SWEET_S3_BUCKET_NAME=ysweet-testing-y-sweet-data
-export Y_SWEET_MINIO_PORT=9000
+export RELAY_S3_BUCKET_PREFIX=testing
+export RELAY_S3_BUCKET_NAME=ysweet-testing-y-sweet-data
+export RELAY_MINIO_PORT=9000
 
 npm test
 


### PR DESCRIPTION
## Summary
- replace `Y_SWEET_*` environment variables with `RELAY_*`
- fallback to the old `Y_SWEET_*` names in `run.sh`

## Testing
- `npm test` *(fails: Cannot find module '@y-sweet/sdk')*

------
https://chatgpt.com/codex/tasks/task_e_6879ca5869c08321be02c8098f030717