### PR TITLE
Add Relay-Server-Version header from git tag

### DIFF
--- a/crates/y-sweet/Cargo.toml
+++ b/crates/y-sweet/Cargo.toml
@@ -6,6 +6,7 @@ description = "A standalone Yjs CRDT server with built-in persistence and auth."
 license = "MIT"
 homepage = "https://y-sweet.dev"
 repository = "https://github.com/drifting-in-space/y-sweet"
+build = "build.rs"
 
 [dependencies]
 anyhow = "1.0.72"

--- a/crates/y-sweet/build.rs
+++ b/crates/y-sweet/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--always"])
+        .output();
+
+    let version = match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        _ => "unknown".to_string(),
+    };
+
+    println!("cargo:rustc-env=GIT_VERSION={}", version);
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+}


### PR DESCRIPTION
## Summary
- inject a build script to expose `GIT_VERSION`
- include a new constant `RELAY_SERVER_VERSION`
- add middleware that sets `Relay-Server-Version` on all responses

## Testing
- `cargo check --workspace`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6879cf3fff24832189cb63b28e48dd78