### PR TITLE
fix: Accept server tokens on /download endpoint

### DIFF
--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -3180,60 +3180,91 @@ async fn handle_file_download(
 ) -> Result<Response, AppError> {
     tracing::info!(doc_id = %doc_id, hash = %params.hash, "Handling file download");
 
-    let permission = validate_file_token(&server_state, &params.token, &doc_id)?;
+    let authenticator = server_state.authenticator.as_ref().ok_or_else(|| {
+        AppError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            anyhow!("No authenticator configured"),
+        )
+    })?;
 
-    if let Permission::File(file_permission) = permission {
-        // Both ReadOnly and Full can download files
-        if !matches!(
-            file_permission.authorization,
-            Authorization::ReadOnly | Authorization::Full
-        ) {
-            return Err(AppError::auth(
-                StatusCode::FORBIDDEN,
-                anyhow!("Insufficient permissions to download file"),
-                "insufficient_permissions",
-            ));
-        }
-
-        // Verify the hash parameter matches the token
-        if file_permission.file_hash != params.hash {
-            return Err(AppError::new(
-                StatusCode::BAD_REQUEST,
-                anyhow!("Hash parameter does not match token"),
-            ));
-        }
-
-        // Check if we have a store configured
-        let store = server_state.store.as_ref().ok_or_else(|| {
-            AppError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                anyhow!("No store configured for file downloads"),
+    let permission = authenticator
+        .verify_token_auto(&params.token, current_time_epoch_millis())
+        .map_err(|auth_error| {
+            AppError::auth(
+                StatusCode::UNAUTHORIZED,
+                anyhow!("Invalid token"),
+                auth_error.to_metric_label(),
             )
         })?;
 
-        // Retrieve file
-        let key = format!("files/{}/{}", doc_id, file_permission.file_hash);
-        let file_data = store
-            .get(&key)
-            .await
-            .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.into()))?
-            .ok_or_else(|| AppError::new(StatusCode::NOT_FOUND, anyhow!("File not found")))?;
+    let (file_hash, content_type) = match permission {
+        Permission::File(ref file_permission) => {
+            if file_permission.doc_id != doc_id {
+                return Err(AppError::auth(
+                    StatusCode::UNAUTHORIZED,
+                    anyhow!("Token not valid for this document"),
+                    "access_wrong_document",
+                ));
+            }
+            if !matches!(
+                file_permission.authorization,
+                Authorization::ReadOnly | Authorization::Full
+            ) {
+                return Err(AppError::auth(
+                    StatusCode::FORBIDDEN,
+                    anyhow!("Insufficient permissions to download file"),
+                    "insufficient_permissions",
+                ));
+            }
+            if file_permission.file_hash != params.hash {
+                return Err(AppError::new(
+                    StatusCode::BAD_REQUEST,
+                    anyhow!("Hash parameter does not match token"),
+                ));
+            }
+            (
+                file_permission.file_hash.clone(),
+                file_permission
+                    .content_type
+                    .clone()
+                    .unwrap_or_else(|| "application/octet-stream".to_string()),
+            )
+        }
+        Permission::Server => {
+            if !validate_file_hash(&params.hash) {
+                return Err(AppError::new(
+                    StatusCode::BAD_REQUEST,
+                    anyhow!("Invalid file hash format"),
+                ));
+            }
+            (params.hash.clone(), "application/octet-stream".to_string())
+        }
+        _ => {
+            return Err(AppError::new(
+                StatusCode::BAD_REQUEST,
+                anyhow!("Token must be a file token or server token"),
+            ));
+        }
+    };
 
-        // Stream response
-        let content_type = file_permission
-            .content_type
-            .unwrap_or_else(|| "application/octet-stream".to_string());
+    let store = server_state.store.as_ref().ok_or_else(|| {
+        AppError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            anyhow!("No store configured for file downloads"),
+        )
+    })?;
 
-        Ok(Response::builder()
-            .status(StatusCode::OK)
-            .header("content-type", content_type)
-            .header("content-length", file_data.len())
-            .body(axum::body::Body::from(file_data))
-            .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.into()))?)
-    } else {
-        Err(AppError::new(
-            StatusCode::BAD_REQUEST,
-            anyhow!("Invalid permission type"),
-        ))
-    }
+    let key = format!("files/{}/{}", doc_id, file_hash);
+    let file_data = store
+        .get(&key)
+        .await
+        .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.into()))?
+        .ok_or_else(|| AppError::new(StatusCode::NOT_FOUND, anyhow!("File not found")))?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", content_type)
+        .header("content-length", file_data.len())
+        .body(axum::body::Body::from(file_data))
+        .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, e.into()))?)
 }


### PR DESCRIPTION
## Summary

The `/download-url` endpoint accepts server tokens and generates a presigned URL containing the server token. But the `/download` endpoint only accepts file tokens via `validate_file_token()`, so the presigned URL fails with 400 "Token must be a file token".

This completes the server-token-file-access feature described in `crates/specs/server-token-file-access.md`. The `/download-url` half was already implemented; this does the `/download` half.

## What changed

`handle_file_download` now uses `verify_token_auto` (like `handle_file_download_url` already does) and handles both `Permission::File` and `Permission::Server`:

- **File tokens**: existing behavior - hash from token payload, doc_id validation, permission check
- **Server tokens**: hash from query parameter (validated with `validate_file_hash`), full access

## Context

The relay-git-sync server uses a server token (API key) to sync binary files. The `/download-url` endpoint succeeds and returns a presigned URL, but the presigned URL fails at `/download` because it carries the server token. This blocks all binary file syncing.

## Logs

```
400 Client Error: Bad Request for url:
  .../f/{relay_id}-{folder_id}-{file_id}/download?hash=...&token={server_token}
Response body: "Something went wrong: Token must be a file token"
```