### PR TITLE
demote idle doc_persistence_worker logs to debug

### DIFF
--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -514,7 +514,7 @@ impl Server {
                 }
             };
 
-            tracing::info!("Received signal. done: {}", is_done);
+            tracing::debug!("Received signal. done: {}", is_done);
             let now = std::time::Instant::now();
             if !is_done && now - last_save < checkpoint_freq {
                 let sleep = tokio::time::sleep(checkpoint_freq - (now - last_save));
@@ -541,11 +541,11 @@ impl Server {
                     tracing::info!("Done throttling.");
                 }
             }
-            tracing::info!("Persisting.");
+            tracing::debug!("Persisting.");
             if let Err(e) = sync_kv.persist().await {
                 tracing::error!(?e, "Error persisting.");
             } else {
-                tracing::info!("Done persisting.");
+                tracing::debug!("Done persisting.");
             }
             last_save = std::time::Instant::now();
 


### PR DESCRIPTION
The per-doc persistence worker fires every checkpoint_freq (default 10s) and unconditionally emits three INFO lines — "Received signal", "Persisting", "Done persisting" — even when nothing is dirty. With N connected Y.Docs the log volume scales as 3N every checkpoint interval regardless of activity.

Demote to debug so idle ticks are silent while leaving on-demand persists, throttling transitions, and errors at their current levels.

> NOTE: I'm making this PR mostly for the fun of it, and as a point-in-time record of what we're doing. You probably have reasons you wouldn't want to accept it and that's fine :)