### PR TITLE
Quiet per-doc log chatter; contextualize backpressure and awareness warns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ CLAUDE.md
 .auth*
 .igit
 /scripts/
+/specs/

--- a/crates/relay/Cargo.toml
+++ b/crates/relay/Cargo.toml
@@ -45,3 +45,4 @@ tempfile = "3.8.1"
 [dev-dependencies]
 http = "1.1.0"
 tempfile = "3.8.1"
+tokio = { version = "1.29.1", features = ["test-util"] }

--- a/crates/relay/src/doc_lifecycle.rs
+++ b/crates/relay/src/doc_lifecycle.rs
@@ -1,0 +1,481 @@
+//! Document lifecycle ownership.
+//!
+//! This module owns document identity for the process: `DocRegistry` is
+//! the only way a document enters or leaves memory. Each doc id maps to a
+//! slot whose async mutex serializes loading and eviction, so a caller
+//! either observes a resident doc or waits until the transition that
+//! affects it (a racing load, or an eviction's final store flush) has
+//! completed.
+//!
+//! Slot rules (the single-instance invariant):
+//! - A doc is installed or removed only while holding the slot mutex, and
+//!   only on a slot that is not `defunct`.
+//! - A waiter that acquires the mutex and finds `defunct` retries from the
+//!   map: the slot was removed while it waited.
+//! - Slots are removed at eviction and on failed loads — nothing else
+//!   removes them, so the registry holds no per-doc-id residue.
+
+use dashmap::DashMap;
+use std::future::Future;
+use std::sync::{Arc, RwLock};
+use tokio::sync::Mutex as AsyncMutex;
+use y_sweet_core::doc_sync::DocWithSyncKv;
+
+/// What an evictor decided after inspecting the doc under the slot lock.
+pub enum EvictDecision {
+    /// Remove the doc from the registry. The evictor has already made the
+    /// doc durable (or decided durability is not required).
+    Evict,
+    /// Keep the doc resident (something attached while eviction was
+    /// pending — the "un-evict").
+    Refuse,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum EvictOutcome {
+    Evicted,
+    Refused,
+    /// No resident doc under this id (never loaded, already evicted, or
+    /// an eviction/failed load raced us).
+    Absent,
+}
+
+struct SlotState {
+    doc: Option<Arc<DocWithSyncKv>>,
+    /// Set exactly once, under the slot mutex, when the slot is removed
+    /// from the map. Tells mutex waiters their slot is dead.
+    defunct: bool,
+}
+
+struct Slot {
+    mu: AsyncMutex<()>,
+    state: RwLock<SlotState>,
+}
+
+impl Slot {
+    fn new() -> Self {
+        Self {
+            mu: AsyncMutex::new(()),
+            state: RwLock::new(SlotState {
+                doc: None,
+                defunct: false,
+            }),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct DocRegistry {
+    slots: DashMap<String, Arc<Slot>>,
+}
+
+impl DocRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Lock-free view of a resident doc. During an eviction the doc is
+    /// already withdrawn from the slot, so a peek misses and the caller
+    /// serializes through `get_or_load`.
+    pub fn peek(&self, doc_id: &str) -> Option<Arc<DocWithSyncKv>> {
+        let slot = self.slots.get(doc_id)?;
+        let state = slot.state.read().unwrap();
+        state.doc.clone()
+    }
+
+    pub fn is_resident(&self, doc_id: &str) -> bool {
+        self.peek(doc_id).is_some()
+    }
+
+    /// Snapshot of every resident doc, for shutdown flush passes. Docs
+    /// mid-load or mid-eviction are absent from slot state and therefore
+    /// skipped: a loading doc is clean, and an evicting doc's final flush
+    /// is already someone else's responsibility.
+    pub fn resident_docs(&self) -> Vec<Arc<DocWithSyncKv>> {
+        self.slots
+            .iter()
+            .filter_map(|entry| entry.value().state.read().unwrap().doc.clone())
+            .collect()
+    }
+
+    /// Number of slots (resident docs plus in-flight loads).
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    /// Return the resident doc for `doc_id`, or run `loader` to create it.
+    /// Concurrent callers single-flight: exactly one runs the loader, the
+    /// rest wait on the slot mutex and observe the result. A failed load
+    /// removes the slot and returns the error to the caller that ran the
+    /// loader; waiters retry with their own load rather than inheriting an
+    /// error they can't distinguish from their own.
+    pub async fn get_or_load<F, Fut>(
+        &self,
+        doc_id: &str,
+        loader: F,
+    ) -> anyhow::Result<Arc<DocWithSyncKv>>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
+    {
+        loop {
+            // Fast path: no slot mutex. An evicting doc is already
+            // withdrawn from the slot state, so this cannot observe one.
+            if let Some(slot) = self.slots.get(doc_id) {
+                let doc = slot.state.read().unwrap().doc.clone();
+                if let Some(doc) = doc {
+                    return Ok(doc);
+                }
+            }
+
+            // Take (or create) the slot, dropping the shard guard before
+            // awaiting the slot mutex.
+            let slot = {
+                let entry = self
+                    .slots
+                    .entry(doc_id.to_string())
+                    .or_insert_with(|| Arc::new(Slot::new()));
+                Arc::clone(entry.value())
+            };
+            let _guard = slot.mu.lock().await;
+
+            {
+                let state = slot.state.read().unwrap();
+                if state.defunct {
+                    // The slot was evicted or its load failed while we
+                    // waited; start over from the map.
+                    continue;
+                }
+                if let Some(doc) = state.doc.clone() {
+                    return Ok(doc);
+                }
+            }
+
+            match loader().await {
+                Ok(doc) => {
+                    let doc = Arc::new(doc);
+                    slot.state.write().unwrap().doc = Some(Arc::clone(&doc));
+                    return Ok(doc);
+                }
+                Err(err) => {
+                    slot.state.write().unwrap().defunct = true;
+                    self.slots.remove_if(doc_id, |_, s| Arc::ptr_eq(s, &slot));
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    /// Run `evictor` on the resident doc under the slot lock. The doc is
+    /// withdrawn from the slot before the evictor runs, so no new caller
+    /// can observe it while the final flush is in flight; loads for the
+    /// same id queue on the slot mutex until the eviction completes (and
+    /// then read the store, which already holds the final flush) or until
+    /// a `Refuse` reinstalls the doc.
+    pub async fn evict<F, Fut>(&self, doc_id: &str, evictor: F) -> EvictOutcome
+    where
+        F: FnOnce(Arc<DocWithSyncKv>) -> Fut,
+        Fut: Future<Output = EvictDecision>,
+    {
+        let Some(slot) = self.slots.get(doc_id).map(|s| Arc::clone(s.value())) else {
+            return EvictOutcome::Absent;
+        };
+        let _guard = slot.mu.lock().await;
+
+        let doc = {
+            let mut state = slot.state.write().unwrap();
+            if state.defunct {
+                return EvictOutcome::Absent;
+            }
+            match state.doc.take() {
+                Some(doc) => doc,
+                None => return EvictOutcome::Absent,
+            }
+        };
+
+        match evictor(Arc::clone(&doc)).await {
+            EvictDecision::Refuse => {
+                slot.state.write().unwrap().doc = Some(doc);
+                EvictOutcome::Refused
+            }
+            EvictDecision::Evict => {
+                slot.state.write().unwrap().defunct = true;
+                self.slots.remove_if(doc_id, |_, s| Arc::ptr_eq(s, &slot));
+                EvictOutcome::Evicted
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::{content_update, read_content, FailStore, GatedStore};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use y_sweet_core::store::{memory::MemoryStore, Store};
+
+    async fn load_doc<S: Store + Clone + 'static>(
+        store: &S,
+        doc_id: &str,
+    ) -> anyhow::Result<DocWithSyncKv> {
+        DocWithSyncKv::new(
+            doc_id,
+            Some(Arc::new(Box::new(store.clone()) as Box<dyn Store>)),
+            || (),
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn single_flight_concurrent_loads_share_one_load() {
+        let store = GatedStore::new();
+        let registry = Arc::new(DocRegistry::new());
+        let loads = Arc::new(AtomicUsize::new(0));
+
+        let docs = futures::future::join_all((0..8).map(|_| {
+            let registry = registry.clone();
+            let store = store.clone();
+            let loads = loads.clone();
+            async move {
+                registry
+                    .get_or_load("doc", || {
+                        let store = store.clone();
+                        let loads = loads.clone();
+                        async move {
+                            loads.fetch_add(1, Ordering::SeqCst);
+                            load_doc(&store, "doc").await
+                        }
+                    })
+                    .await
+                    .unwrap()
+            }
+        }))
+        .await;
+
+        assert_eq!(loads.load(Ordering::SeqCst), 1, "loader must run once");
+        assert_eq!(
+            store.get_count("doc/data.ysweet"),
+            1,
+            "store must be read once"
+        );
+        for doc in &docs[1..] {
+            assert!(
+                Arc::ptr_eq(&docs[0], doc),
+                "all callers must share one instance"
+            );
+        }
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_load_propagates_to_all_waiters_and_clears_slot() {
+        // Enough injected failures that every concurrent caller's own
+        // load attempt fails (waiters retry with their own load).
+        let store = FailStore::new(8);
+        let registry = Arc::new(DocRegistry::new());
+
+        let results = futures::future::join_all((0..8).map(|_| {
+            let registry = registry.clone();
+            let store = store.clone();
+            async move {
+                registry
+                    .get_or_load("doc", || {
+                        let store = store.clone();
+                        async move { load_doc(&store, "doc").await }
+                    })
+                    .await
+            }
+        }))
+        .await;
+
+        for result in &results {
+            assert!(result.is_err(), "every caller must see its load fail");
+        }
+        assert_eq!(registry.len(), 0, "failed loads must not leave slots");
+
+        // The failure budget is exhausted; a retry must succeed rather
+        // than finding a wedged slot.
+        registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .expect("retry after failed load must succeed");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_removes_slot_and_next_load_is_fresh() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new();
+
+        let doc = registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .unwrap();
+        doc.apply_update(&content_update("k", "v")).unwrap();
+
+        let outcome = registry
+            .evict("doc", |doc| async move {
+                doc.sync_kv().persist().await.unwrap();
+                EvictDecision::Evict
+            })
+            .await;
+        assert_eq!(outcome, EvictOutcome::Evicted);
+        assert_eq!(registry.len(), 0);
+        assert!(!registry.is_resident("doc"));
+
+        let reloaded = registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .unwrap();
+        assert!(
+            !Arc::ptr_eq(&doc, &reloaded),
+            "a reload after eviction is a fresh instance"
+        );
+        assert_eq!(
+            read_content(&reloaded, "k").as_deref(),
+            Some("v"),
+            "the fresh instance must carry the final-flushed state"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn refused_evict_keeps_doc_resident() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new();
+
+        let doc = registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .unwrap();
+
+        let outcome = registry
+            .evict("doc", |_doc| async move { EvictDecision::Refuse })
+            .await;
+        assert_eq!(outcome, EvictOutcome::Refused);
+        assert_eq!(registry.len(), 1);
+
+        let again = registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .unwrap();
+        assert!(
+            Arc::ptr_eq(&doc, &again),
+            "a refused eviction must keep the same instance"
+        );
+    }
+
+    /// Race 2 (reload racing the final flush) at registry level: a load
+    /// racing an eviction must block until the eviction's final persist is
+    /// on the store, and must then observe the flushed bytes.
+    #[tokio::test(start_paused = true)]
+    async fn evict_holds_slot_against_concurrent_load_until_final_persist() {
+        let store = GatedStore::new();
+        let registry = Arc::new(DocRegistry::new());
+
+        let doc = registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .unwrap();
+        doc.apply_update(&content_update("k", "v")).unwrap();
+        drop(doc);
+
+        store.close_gate();
+
+        let evict_handle = tokio::spawn({
+            let registry = registry.clone();
+            async move {
+                registry
+                    .evict("doc", |doc| async move {
+                        doc.sync_kv().persist().await.unwrap();
+                        EvictDecision::Evict
+                    })
+                    .await
+            }
+        });
+        // Let the eviction reach the gated PUT.
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+
+        let load_handle = tokio::spawn({
+            let registry = registry.clone();
+            let store = store.clone();
+            async move {
+                registry
+                    .get_or_load("doc", move || {
+                        let store = store.clone();
+                        async move { load_doc(&store, "doc").await }
+                    })
+                    .await
+            }
+        });
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !evict_handle.is_finished(),
+            "eviction must be parked on the gated final persist"
+        );
+        assert!(
+            !load_handle.is_finished(),
+            "a racing load must wait for the final persist, not read a stale snapshot"
+        );
+
+        store.release(1);
+        assert_eq!(evict_handle.await.unwrap(), EvictOutcome::Evicted);
+        let reloaded = load_handle.await.unwrap().unwrap();
+        assert_eq!(
+            read_content(&reloaded, "k").as_deref(),
+            Some("v"),
+            "the racing load must observe the final flush"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn slot_count_returns_to_zero_after_load_evict_cycles() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new();
+
+        for round in 0..10 {
+            registry
+                .get_or_load("doc", || {
+                    let store = store.clone();
+                    async move { load_doc(&store, "doc").await }
+                })
+                .await
+                .unwrap();
+            assert_eq!(registry.len(), 1);
+            let outcome = registry
+                .evict("doc", |_doc| async move { EvictDecision::Evict })
+                .await;
+            assert_eq!(outcome, EvictOutcome::Evicted);
+            assert_eq!(
+                registry.len(),
+                0,
+                "round {round}: eviction must fully reclaim the slot"
+            );
+        }
+    }
+}

--- a/crates/relay/src/doc_lifecycle.rs
+++ b/crates/relay/src/doc_lifecycle.rs
@@ -1,11 +1,11 @@
 //! Document lifecycle ownership.
 //!
-//! This module owns document identity for the process: `DocRegistry` is
-//! the only way a document enters or leaves memory. Each doc id maps to a
-//! slot whose async mutex serializes loading and eviction, so a caller
-//! either observes a resident doc or waits until the transition that
-//! affects it (a racing load, or an eviction's final store flush) has
-//! completed.
+//! This module owns document identity and lifecycle for the process:
+//! `DocRegistry` is the only way a document enters or leaves memory, and
+//! each resident doc is owned by a lifecycle actor whose mailbox order
+//! decides every race between attachment and eviction. A caller either
+//! observes a resident doc or waits until the transition that affects it
+//! (a racing load, or an eviction's final store flush) has completed.
 //!
 //! Slot rules (the single-instance invariant):
 //! - A doc is installed or removed only while holding the slot mutex, and
@@ -14,13 +14,24 @@
 //!   map: the slot was removed while it waited.
 //! - Slots are removed at eviction and on failed loads — nothing else
 //!   removes them, so the registry holds no per-doc-id residue.
+//!
+//! Eviction rules (orphans are unrepresentable by message order):
+//! - Only the actor decides eviction, by processing `Evict` in mailbox
+//!   order: any attach granted before it makes `connections > 0` and the
+//!   eviction is refused. An attach that reaches a dying actor gets no
+//!   reply and retries through the slot mutex, which the evictor holds
+//!   until the final flush is on the store and the slot is gone.
+//! - A doc leaves memory only clean: the eviction flush loops until the
+//!   dirty bit clears, and persistent store failure refuses the eviction
+//!   instead of dropping unflushed state.
 
 use dashmap::DashMap;
 use std::future::Future;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-    watch, Mutex as AsyncMutex,
+    oneshot, watch, Mutex as AsyncMutex,
 };
 use y_sweet_core::{
     doc_sync::DocWithSyncKv, metrics::RelayMetrics, sync::awareness::Awareness, sync_kv::SyncKv,
@@ -51,22 +62,64 @@ pub enum LifecycleState {
     Idle,
 }
 
-/// Mailbox messages for a doc's lifecycle actor. In the shadow-accounting
-/// phase the actor only maintains explicit connection counts; eviction
-/// authority moves here in a later migration step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictOutcome {
+    Evicted,
+    Refused,
+    /// No resident doc under this id (never loaded, already evicted, or
+    /// an eviction/failed load raced us).
+    Absent,
+}
+
+/// Lifecycle knobs, shared by every actor the registry spawns.
+#[derive(Clone, Copy)]
+pub struct LifecycleConfig {
+    pub checkpoint_freq: Duration,
+    /// Whether idle docs are evicted at all. When false the idle deadline
+    /// is never armed and docs stay resident for the process lifetime.
+    pub doc_gc: bool,
+}
+
+impl LifecycleConfig {
+    /// Idle deadline: how long a doc sits at zero connections before its
+    /// actor requests eviction (matches the historical two-probe cadence).
+    fn idle_timeout(&self) -> Duration {
+        self.checkpoint_freq * 2
+    }
+}
+
+/// Mailbox messages for a doc's lifecycle actor. Mailbox order is the
+/// arbiter for attach-vs-evict races.
 pub enum DocMsg {
     Attach {
         kind: AttachKind,
+        /// Granted by the actor incrementing its count before replying. A
+        /// dropped reply means the actor is evicting or gone: retry
+        /// through the registry's slot mutex.
+        reply: oneshot::Sender<()>,
     },
     Detach {
         kind: AttachKind,
     },
-    #[allow(dead_code)] // authoritative from the persistence step onward
+    #[allow(dead_code)] // authoritative once the actor owns the throttle
     Dirty,
+    Evict {
+        reply: oneshot::Sender<EvictOutcome>,
+    },
+}
+
+/// Actor → registry sweeper messages.
+enum Control {
+    EvictRequest {
+        doc_id: String,
+        /// Identifies the requesting actor instance; a request from an
+        /// instance that is no longer installed is stale and ignored.
+        tx: UnboundedSender<DocMsg>,
+    },
 }
 
 /// Handle to a doc's lifecycle actor. Cloned into the registry slot and
-/// every guard; the actor exits when the last sender is gone.
+/// every guard; the actor exits when it evicts or the last sender is gone.
 #[derive(Clone)]
 pub struct DocHandle {
     tx: UnboundedSender<DocMsg>,
@@ -74,29 +127,37 @@ pub struct DocHandle {
 }
 
 impl DocHandle {
-    /// Attach to the doc: counts the attachment and returns the RAII
-    /// guard carrying the data-plane handles. The guard holds a strong
-    /// awareness clone so the (still-authoritative) strong-count liveness
-    /// probes see guards exactly as they saw raw awareness refs.
-    pub fn attach(&self, kind: AttachKind, doc: &Arc<DocWithSyncKv>) -> AttachGuard {
-        // Unbounded send: never blocks; failure means the actor is gone,
-        // in which case there is no count left to maintain.
-        let _ = self.tx.send(DocMsg::Attach { kind });
-        AttachGuard {
-            kind,
-            awareness: doc.awareness(),
-            doc: Arc::clone(doc),
-            tx: self.tx.clone(),
-        }
-    }
-
-    /// Explicit connection count as the actor sees it. Shadow-accounting
-    /// accessor: exists so the GC worker can compare counts against the
-    /// strong-count probe; deleted when eviction flips to the counts.
-    pub fn connections(&self) -> usize {
-        match *self.state.borrow() {
-            LifecycleState::Active { connections } => connections,
-            LifecycleState::Idle => 0,
+    /// Ask the actor to grant an attachment. The `Attach` message is
+    /// enqueued eagerly — before the returned future is first polled — so
+    /// callers holding the future have already taken their place in the
+    /// mailbox order that arbitrates against `Evict`. Resolving to `None`
+    /// means the actor is evicting or gone: retry through the slot mutex.
+    pub fn attach(
+        &self,
+        kind: AttachKind,
+        doc: &Arc<DocWithSyncKv>,
+    ) -> impl Future<Output = Option<AttachGuard>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let sent = self
+            .tx
+            .send(DocMsg::Attach {
+                kind,
+                reply: reply_tx,
+            })
+            .is_ok();
+        let tx = self.tx.clone();
+        let doc = Arc::clone(doc);
+        async move {
+            if !sent {
+                return None;
+            }
+            reply_rx.await.ok()?;
+            Some(AttachGuard {
+                kind,
+                awareness: doc.awareness(),
+                doc,
+                tx,
+            })
         }
     }
 
@@ -111,9 +172,6 @@ impl DocHandle {
 pub struct AttachGuard {
     kind: AttachKind,
     doc: Arc<DocWithSyncKv>,
-    /// Strong awareness clone, held for the shadow-accounting phase: the
-    /// strong-count probes must see one ref per attachment, exactly as
-    /// they saw the raw clones this guard replaces.
     awareness: Arc<RwLock<Awareness>>,
     tx: UnboundedSender<DocMsg>,
 }
@@ -145,33 +203,62 @@ pub(crate) struct Resident {
     pub handle: DocHandle,
 }
 
-/// The per-doc lifecycle actor. In this phase it is a pure connection
-/// ledger: it processes Attach/Detach in mailbox order, publishes the
-/// resulting state on a watch channel, and emits transition metrics.
+/// The per-doc lifecycle actor: connection ledger, idle deadline, and
+/// eviction authority. It owns the doc's exit: nothing leaves the
+/// registry without this actor flushing it clean first.
 struct DocActor {
     doc_id: String,
+    doc: Arc<DocWithSyncKv>,
     mailbox: UnboundedReceiver<DocMsg>,
+    /// The actor's own sender, used to identify this instance in
+    /// `Control::EvictRequest`.
+    tx: UnboundedSender<DocMsg>,
+    ctl: UnboundedSender<Control>,
     state_tx: watch::Sender<LifecycleState>,
     sockets: usize,
     https: usize,
     subdocs: usize,
+    /// Armed while idle (and `doc_gc`); firing sends one `EvictRequest`.
+    idle_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
+    evict_requested: bool,
+    /// The idle-entry flush runs as a sub-task so the mailbox stays
+    /// responsive; eviction awaits it before its own flush.
+    persist_inflight: Option<tokio::task::JoinHandle<()>>,
+    cfg: LifecycleConfig,
     metrics: Arc<RelayMetrics>,
 }
 
 impl DocActor {
-    fn spawn(doc_id: String, metrics: Arc<RelayMetrics>) -> DocHandle {
+    #[allow(clippy::too_many_arguments)]
+    fn spawn(
+        doc_id: String,
+        doc: Arc<DocWithSyncKv>,
+        cfg: LifecycleConfig,
+        metrics: Arc<RelayMetrics>,
+        ctl: UnboundedSender<Control>,
+    ) -> DocHandle {
         let (tx, mailbox) = unbounded_channel();
         let (state_tx, state_rx) = watch::channel(LifecycleState::Idle);
         metrics.record_lifecycle_transition("loading", "idle");
-        let actor = DocActor {
+        let mut actor = DocActor {
             doc_id,
+            doc,
             mailbox,
+            tx: tx.clone(),
+            ctl,
             state_tx,
             sockets: 0,
             https: 0,
             subdocs: 0,
+            idle_deadline: None,
+            evict_requested: false,
+            persist_inflight: None,
+            cfg,
             metrics,
         };
+        // A doc is born idle: loads that never attach (doc creation,
+        // warm-ups) age out on the same deadline as any other idle doc.
+        actor.arm_idle_deadline();
         tokio::spawn(actor.run());
         DocHandle {
             tx,
@@ -183,51 +270,175 @@ impl DocActor {
         self.sockets + self.https + self.subdocs
     }
 
+    fn arm_idle_deadline(&mut self) {
+        if self.cfg.doc_gc {
+            self.idle_deadline = Some(Box::pin(tokio::time::sleep(self.cfg.idle_timeout())));
+        }
+    }
+
     async fn run(mut self) {
-        // The slot holds one sender and each guard holds one; the actor
-        // ends when the doc is evicted and the last guard is gone.
-        while let Some(msg) = self.mailbox.recv().await {
-            match msg {
-                DocMsg::Attach { kind } => {
-                    let was = self.connections();
-                    match kind {
-                        AttachKind::Socket => self.sockets += 1,
-                        AttachKind::Http => self.https += 1,
-                        AttachKind::Subdoc => self.subdocs += 1,
-                    }
-                    if was == 0 {
-                        self.metrics.record_lifecycle_transition("idle", "active");
-                    }
-                    self.publish();
-                    tracing::debug!(
-                        doc_id = %self.doc_id,
-                        kind = kind.as_str(),
-                        connections = self.connections(),
-                        "attach"
-                    );
+        loop {
+            let event = {
+                let deadline = &mut self.idle_deadline;
+                let mailbox = &mut self.mailbox;
+                tokio::select! {
+                    msg = mailbox.recv() => Some(msg),
+                    _ = async {
+                        match deadline {
+                            Some(sleep) => sleep.as_mut().await,
+                            None => std::future::pending().await,
+                        }
+                    } => None,
                 }
-                DocMsg::Detach { kind } => {
-                    let counter = match kind {
-                        AttachKind::Socket => &mut self.sockets,
-                        AttachKind::Http => &mut self.https,
-                        AttachKind::Subdoc => &mut self.subdocs,
-                    };
-                    debug_assert!(*counter > 0, "detach without matching attach");
-                    *counter = counter.saturating_sub(1);
-                    if self.connections() == 0 {
-                        self.metrics.record_lifecycle_transition("active", "idle");
+            };
+            match event {
+                // Slot dropped and every guard gone; nothing left to own.
+                Some(None) => break,
+                Some(Some(msg)) => {
+                    if self.handle_msg(msg).await {
+                        break;
                     }
-                    self.publish();
-                    tracing::debug!(
-                        doc_id = %self.doc_id,
-                        kind = kind.as_str(),
-                        connections = self.connections(),
-                        "detach"
-                    );
                 }
-                DocMsg::Dirty => {}
+                None => {
+                    // Idle deadline fired: hand the decision to the
+                    // registry, which serializes eviction under the slot
+                    // mutex. Do not re-arm; the request stays pending
+                    // until an `Evict` (or an attach) resolves it.
+                    self.idle_deadline = None;
+                    if !self.evict_requested {
+                        self.evict_requested = true;
+                        let _ = self.ctl.send(Control::EvictRequest {
+                            doc_id: self.doc_id.clone(),
+                            tx: self.tx.clone(),
+                        });
+                    }
+                }
             }
         }
+    }
+
+    /// Returns true when the actor should exit (the doc was evicted).
+    async fn handle_msg(&mut self, msg: DocMsg) -> bool {
+        match msg {
+            DocMsg::Attach { kind, reply } => {
+                let was = self.connections();
+                match kind {
+                    AttachKind::Socket => self.sockets += 1,
+                    AttachKind::Http => self.https += 1,
+                    AttachKind::Subdoc => self.subdocs += 1,
+                }
+                if was == 0 {
+                    self.idle_deadline = None;
+                    self.metrics.record_lifecycle_transition("idle", "active");
+                }
+                self.publish();
+                let _ = reply.send(());
+                tracing::debug!(
+                    doc_id = %self.doc_id,
+                    kind = kind.as_str(),
+                    connections = self.connections(),
+                    "attach"
+                );
+                false
+            }
+            DocMsg::Detach { kind } => {
+                let counter = match kind {
+                    AttachKind::Socket => &mut self.sockets,
+                    AttachKind::Http => &mut self.https,
+                    AttachKind::Subdoc => &mut self.subdocs,
+                };
+                debug_assert!(*counter > 0, "detach without matching attach");
+                *counter = counter.saturating_sub(1);
+                if self.connections() == 0 {
+                    self.metrics.record_lifecycle_transition("active", "idle");
+                    self.idle_entry_flush();
+                    self.arm_idle_deadline();
+                }
+                self.publish();
+                tracing::debug!(
+                    doc_id = %self.doc_id,
+                    kind = kind.as_str(),
+                    connections = self.connections(),
+                    "detach"
+                );
+                false
+            }
+            DocMsg::Dirty => false,
+            DocMsg::Evict { reply } => self.handle_evict(reply).await,
+        }
+    }
+
+    /// Idle entry is a durability point: the machine may be suspended any
+    /// time after the last connection drains, so whatever the checkpoint
+    /// throttle is still holding gets flushed now, as a sub-task that
+    /// keeps the mailbox responsive.
+    fn idle_entry_flush(&mut self) {
+        if !self.doc.sync_kv().is_dirty() {
+            return;
+        }
+        self.metrics.record_doc_dirty_at_drain();
+        let sync_kv = self.doc.sync_kv();
+        let doc_id = self.doc_id.clone();
+        self.persist_inflight = Some(tokio::spawn(async move {
+            if let Err(e) = sync_kv.persist().await {
+                tracing::error!(?e, doc_id = %doc_id, "Error persisting at idle entry");
+            }
+        }));
+    }
+
+    async fn handle_evict(&mut self, reply: oneshot::Sender<EvictOutcome>) -> bool {
+        self.evict_requested = false;
+        // Any attach granted ahead of this message in the mailbox has
+        // already incremented the count — this check IS the un-evict.
+        if self.connections() > 0 {
+            tracing::info!(doc_id = %self.doc_id, "attach raced eviction; refusing evict");
+            let _ = reply.send(EvictOutcome::Refused);
+            return false;
+        }
+        self.idle_deadline = None;
+        self.metrics.record_lifecycle_transition("idle", "evicting");
+        if let Some(inflight) = self.persist_inflight.take() {
+            let _ = inflight.await;
+        }
+        tracing::info!(doc_id = %self.doc_id, "evicting doc");
+        // Compact PUD before exit: dedup ids, clear ds. The mutations
+        // create tombstones which yrs GC will clean up, and the update
+        // observer marks SyncKv dirty so the compacted state persists in
+        // the flush below.
+        let result = self.doc.compact_user_data();
+        if !result.is_empty() {
+            tracing::debug!(
+                ids_removed = result.ids_removed,
+                ds_removed = result.ds_removed,
+                "Compacted PermanentUserData"
+            );
+        }
+        // Flush until clean: the final state must reach the store before
+        // the registry clears the slot, or a reload would read a stale
+        // snapshot and its next persist would roll the doc back. A doc
+        // never leaves memory unflushed: persistent store failure keeps
+        // it resident and retries on the next idle deadline.
+        let mut failures = 0;
+        while self.doc.sync_kv().is_dirty() {
+            if let Err(e) = self.doc.sync_kv().persist().await {
+                failures += 1;
+                tracing::error!(?e, doc_id = %self.doc_id, "Error persisting during eviction");
+                if failures >= 3 {
+                    self.metrics.record_lifecycle_transition("evicting", "idle");
+                    self.arm_idle_deadline();
+                    let _ = reply.send(EvictOutcome::Refused);
+                    return false;
+                }
+            }
+        }
+        self.metrics.record_lifecycle_transition("evicting", "gone");
+        // Transitional, until the actor owns the persistence throttle:
+        // the per-doc persistence worker polls this flag to learn its doc
+        // is gone and exit.
+        self.doc.sync_kv().shutdown();
+        let _ = reply.send(EvictOutcome::Evicted);
+        // Returning true drops the actor and with it the doc instance.
+        true
     }
 
     fn publish(&self) {
@@ -237,45 +448,6 @@ impl DocActor {
         };
         let _ = self.state_tx.send(state);
     }
-}
-
-/// A bare actor handle for harnesses that drive the socket path without
-/// a registry (see `server.rs`'s in-memory socket tests).
-#[cfg(test)]
-pub(crate) fn test_actor_handle(doc_id: &str, metrics: Arc<RelayMetrics>) -> DocHandle {
-    DocActor::spawn(doc_id.to_string(), metrics)
-}
-
-/// The shadow-accounting comparison: does the explicit connection count
-/// agree with the awareness strong-count probe? A single-instant mismatch
-/// can be an attach/detach caught mid-flight (the guard's awareness clone
-/// and its mailbox message are not atomic), so callers only record a
-/// mismatch after it persists across two consecutive checks.
-/// Returns whether this check disagreed.
-pub(crate) fn shadow_accounting_disagrees(resident: &Resident) -> bool {
-    let probe = Arc::downgrade(&resident.doc.awareness());
-    let strong_alive = probe.strong_count() > 1;
-    let counted_alive = resident.handle.connections() > 0;
-    strong_alive != counted_alive
-}
-
-/// What an evictor decided after inspecting the doc under the slot lock.
-pub enum EvictDecision {
-    /// Remove the doc from the registry. The evictor has already made the
-    /// doc durable (or decided durability is not required).
-    Evict,
-    /// Keep the doc resident (something attached while eviction was
-    /// pending — the "un-evict").
-    Refuse,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum EvictOutcome {
-    Evicted,
-    Refused,
-    /// No resident doc under this id (never loaded, already evicted, or
-    /// an eviction/failed load raced us).
-    Absent,
 }
 
 struct SlotState {
@@ -303,21 +475,62 @@ impl Slot {
 }
 
 pub struct DocRegistry {
-    slots: DashMap<String, Arc<Slot>>,
+    slots: Arc<DashMap<String, Arc<Slot>>>,
+    ctl_tx: UnboundedSender<Control>,
+    cfg: LifecycleConfig,
     metrics: Arc<RelayMetrics>,
 }
 
 impl DocRegistry {
-    pub fn new(metrics: Arc<RelayMetrics>) -> Self {
+    pub fn new(metrics: Arc<RelayMetrics>, cfg: LifecycleConfig) -> Self {
+        let slots: Arc<DashMap<String, Arc<Slot>>> = Arc::new(DashMap::new());
+        let (ctl_tx, ctl_rx) = unbounded_channel();
+        Self::spawn_sweeper(Arc::clone(&slots), ctl_rx);
         Self {
-            slots: DashMap::new(),
+            slots,
+            ctl_tx,
+            cfg,
             metrics,
         }
     }
 
-    /// Lock-free view of a resident doc. During an eviction the doc is
-    /// already withdrawn from the slot, so a peek misses and the caller
-    /// serializes through `get_or_load`.
+    /// The sweeper serializes actor-requested evictions under the slot
+    /// mutex, one at a time. A request from an actor instance that is no
+    /// longer installed (evicted and reloaded since) is stale and ignored.
+    fn spawn_sweeper(
+        slots: Arc<DashMap<String, Arc<Slot>>>,
+        mut ctl_rx: UnboundedReceiver<Control>,
+    ) {
+        tokio::spawn(async move {
+            while let Some(msg) = ctl_rx.recv().await {
+                match msg {
+                    Control::EvictRequest { doc_id, tx } => {
+                        let current = slots
+                            .get(&doc_id)
+                            .and_then(|s| s.value().state.read().unwrap().doc.clone());
+                        let stale = match current {
+                            Some(resident) => !resident.handle.tx.same_channel(&tx),
+                            None => true,
+                        };
+                        if stale {
+                            continue;
+                        }
+                        match Self::evict_in(&slots, &doc_id).await {
+                            EvictOutcome::Evicted => {
+                                tracing::debug!(doc_id = %doc_id, "idle doc evicted");
+                            }
+                            EvictOutcome::Refused => {
+                                tracing::debug!(doc_id = %doc_id, "eviction refused; doc active again");
+                            }
+                            EvictOutcome::Absent => {}
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /// Lock-free view of a resident doc.
     pub fn peek(&self, doc_id: &str) -> Option<Arc<DocWithSyncKv>> {
         self.peek_resident(doc_id).map(|r| r.doc)
     }
@@ -328,30 +541,13 @@ impl DocRegistry {
         state.doc.clone()
     }
 
-    /// Load (if needed) and attach in one step: the returned guard is the
-    /// unit of explicit connection accounting.
-    pub async fn attach<F, Fut>(
-        &self,
-        doc_id: &str,
-        kind: AttachKind,
-        loader: F,
-    ) -> anyhow::Result<AttachGuard>
-    where
-        F: Fn() -> Fut,
-        Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
-    {
-        let resident = self.get_or_load_resident(doc_id, loader).await?;
-        Ok(resident.handle.attach(kind, &resident.doc))
-    }
-
     pub fn is_resident(&self, doc_id: &str) -> bool {
-        self.peek(doc_id).is_some()
+        self.peek_resident(doc_id).is_some()
     }
 
     /// Snapshot of every resident doc, for shutdown flush passes. Docs
-    /// mid-load or mid-eviction are absent from slot state and therefore
-    /// skipped: a loading doc is clean, and an evicting doc's final flush
-    /// is already someone else's responsibility.
+    /// mid-load are absent from slot state and therefore skipped: a
+    /// loading doc is clean.
     pub fn resident_docs(&self) -> Vec<Arc<DocWithSyncKv>> {
         self.slots
             .iter()
@@ -369,12 +565,35 @@ impl DocRegistry {
         self.slots.is_empty()
     }
 
-    /// Return the resident doc for `doc_id`, or run `loader` to create it.
-    /// Concurrent callers single-flight: exactly one runs the loader, the
-    /// rest wait on the slot mutex and observe the result. A failed load
-    /// removes the slot and returns the error to the caller that ran the
-    /// loader; waiters retry with their own load rather than inheriting an
-    /// error they can't distinguish from their own.
+    /// Load (if needed) and attach in one step: the returned guard is the
+    /// unit of connection accounting and the only license to touch the
+    /// doc. Retries are bounded: any pass that reaches the load branch
+    /// succeeds, so the budget is a formality.
+    pub async fn attach<F, Fut>(
+        &self,
+        doc_id: &str,
+        kind: AttachKind,
+        loader: F,
+    ) -> anyhow::Result<AttachGuard>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
+    {
+        let mut skip_fast_path = false;
+        for _ in 0..4 {
+            let resident = self.load_resident(doc_id, &loader, skip_fast_path).await?;
+            match resident.handle.attach(kind, &resident.doc).await {
+                Some(guard) => return Ok(guard),
+                // The actor is evicting or gone. The fast path would keep
+                // returning the same dying resident, so the retry
+                // serializes on the slot mutex, which the evictor holds
+                // until the slot clears (and which reclaims dead actors).
+                None => skip_fast_path = true,
+            }
+        }
+        anyhow::bail!("attach retry budget exceeded for doc {doc_id}")
+    }
+
     pub async fn get_or_load<F, Fut>(
         &self,
         doc_id: &str,
@@ -384,25 +603,45 @@ impl DocRegistry {
         F: Fn() -> Fut,
         Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
     {
-        Ok(self.get_or_load_resident(doc_id, loader).await?.doc)
+        Ok(self.get_or_load_resident(doc_id, &loader).await?.doc)
     }
 
+    /// Return the resident doc for `doc_id`, or run `loader` to create it.
+    /// Concurrent callers single-flight: exactly one runs the loader, the
+    /// rest wait on the slot mutex and observe the result. A failed load
+    /// removes the slot and returns the error to the caller that ran the
+    /// loader; waiters retry with their own load rather than inheriting an
+    /// error they can't distinguish from their own.
     async fn get_or_load_resident<F, Fut>(
         &self,
         doc_id: &str,
-        loader: F,
+        loader: &F,
+    ) -> anyhow::Result<Resident>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
+    {
+        self.load_resident(doc_id, loader, false).await
+    }
+
+    async fn load_resident<F, Fut>(
+        &self,
+        doc_id: &str,
+        loader: &F,
+        mut skip_fast_path: bool,
     ) -> anyhow::Result<Resident>
     where
         F: Fn() -> Fut,
         Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
     {
         loop {
-            // Fast path: no slot mutex. An evicting doc is already
-            // withdrawn from the slot state, so this cannot observe one.
-            if let Some(slot) = self.slots.get(doc_id) {
-                let resident = slot.state.read().unwrap().doc.clone();
-                if let Some(resident) = resident {
-                    return Ok(resident);
+            // Fast path: no slot mutex.
+            if !std::mem::take(&mut skip_fast_path) {
+                if let Some(slot) = self.slots.get(doc_id) {
+                    let resident = slot.state.read().unwrap().doc.clone();
+                    if let Some(resident) = resident {
+                        return Ok(resident);
+                    }
                 }
             }
 
@@ -425,16 +664,34 @@ impl DocRegistry {
                     continue;
                 }
                 if let Some(resident) = state.doc.clone() {
-                    return Ok(resident);
+                    if !resident.handle.tx.is_closed() {
+                        return Ok(resident);
+                    }
+                    // The actor died without the registry noticing (it
+                    // panicked): fall through, reclaim the slot, and load
+                    // fresh below.
+                    tracing::warn!(doc_id = %doc_id, "resident doc's actor is dead; reloading");
                 }
+            }
+
+            if slot.state.read().unwrap().doc.is_some() {
+                // Dead-actor branch from above: reclaim under the mutex.
+                slot.state.write().unwrap().defunct = true;
+                self.slots.remove_if(doc_id, |_, s| Arc::ptr_eq(s, &slot));
+                continue;
             }
 
             match loader().await {
                 Ok(doc) => {
-                    let resident = Resident {
-                        doc: Arc::new(doc),
-                        handle: DocActor::spawn(doc_id.to_string(), self.metrics.clone()),
-                    };
+                    let doc = Arc::new(doc);
+                    let handle = DocActor::spawn(
+                        doc_id.to_string(),
+                        Arc::clone(&doc),
+                        self.cfg,
+                        self.metrics.clone(),
+                        self.ctl_tx.clone(),
+                    );
+                    let resident = Resident { doc, handle };
                     slot.state.write().unwrap().doc = Some(resident.clone());
                     return Ok(resident);
                 }
@@ -447,45 +704,80 @@ impl DocRegistry {
         }
     }
 
-    /// Run `evictor` on the resident doc under the slot lock. The doc is
-    /// withdrawn from the slot before the evictor runs, so no new caller
-    /// can observe it while the final flush is in flight; loads for the
-    /// same id queue on the slot mutex until the eviction completes (and
-    /// then read the store, which already holds the final flush) or until
-    /// a `Refuse` reinstalls the doc.
-    pub async fn evict<F, Fut>(&self, doc_id: &str, evictor: F) -> EvictOutcome
-    where
-        F: FnOnce(Arc<DocWithSyncKv>) -> Fut,
-        Fut: Future<Output = EvictDecision>,
-    {
-        let Some(slot) = self.slots.get(doc_id).map(|s| Arc::clone(s.value())) else {
+    /// Evict `doc_id` now (the sweeper's path, also exposed so tests and
+    /// shutdown paths can drive eviction explicitly). Holds the slot
+    /// mutex across the actor's final flush: a racing load waits until
+    /// the store already holds the flushed bytes.
+    pub async fn evict(&self, doc_id: &str) -> EvictOutcome {
+        Self::evict_in(&self.slots, doc_id).await
+    }
+
+    async fn evict_in(slots: &DashMap<String, Arc<Slot>>, doc_id: &str) -> EvictOutcome {
+        let Some(slot) = slots.get(doc_id).map(|s| Arc::clone(s.value())) else {
             return EvictOutcome::Absent;
         };
         let _guard = slot.mu.lock().await;
 
         let resident = {
-            let mut state = slot.state.write().unwrap();
+            let state = slot.state.read().unwrap();
             if state.defunct {
                 return EvictOutcome::Absent;
             }
-            match state.doc.take() {
+            match state.doc.clone() {
                 Some(resident) => resident,
                 None => return EvictOutcome::Absent,
             }
         };
 
-        match evictor(Arc::clone(&resident.doc)).await {
-            EvictDecision::Refuse => {
-                slot.state.write().unwrap().doc = Some(resident);
-                EvictOutcome::Refused
-            }
-            EvictDecision::Evict => {
-                slot.state.write().unwrap().defunct = true;
-                self.slots.remove_if(doc_id, |_, s| Arc::ptr_eq(s, &slot));
+        let remove_slot = || {
+            slot.state.write().unwrap().doc = None;
+            slot.state.write().unwrap().defunct = true;
+            slots.remove_if(doc_id, |_, s| Arc::ptr_eq(s, &slot));
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if resident
+            .handle
+            .tx
+            .send(DocMsg::Evict { reply: reply_tx })
+            .is_err()
+        {
+            // Dead actor: reclaim the slot; the doc was flushed at its
+            // last idle entry or not at all — a panic loses the tail.
+            tracing::warn!(doc_id = %doc_id, "evicting a dead actor's slot");
+            remove_slot();
+            return EvictOutcome::Absent;
+        }
+        match reply_rx.await {
+            Ok(EvictOutcome::Evicted) => {
+                remove_slot();
                 EvictOutcome::Evicted
+            }
+            Ok(outcome) => outcome,
+            Err(_) => {
+                tracing::error!(doc_id = %doc_id, "actor died during eviction; flush state unknown");
+                remove_slot();
+                EvictOutcome::Absent
             }
         }
     }
+}
+
+/// A bare actor handle for harnesses that drive the socket path without
+/// a registry (see `server.rs`'s in-memory socket tests).
+#[cfg(test)]
+pub(crate) fn test_actor_handle(doc: &Arc<DocWithSyncKv>, metrics: Arc<RelayMetrics>) -> DocHandle {
+    let (ctl_tx, _ctl_rx) = unbounded_channel();
+    DocActor::spawn(
+        "test_doc".to_string(),
+        Arc::clone(doc),
+        LifecycleConfig {
+            checkpoint_freq: Duration::from_secs(600),
+            doc_gc: false,
+        },
+        metrics,
+        ctl_tx,
+    )
 }
 
 #[cfg(test)]
@@ -499,9 +791,16 @@ mod tests {
         RelayMetrics::new_with_registry(&prometheus::Registry::new()).unwrap()
     }
 
-    /// Let the actor drain its mailbox (single-threaded test runtime).
+    fn no_gc() -> LifecycleConfig {
+        LifecycleConfig {
+            checkpoint_freq: Duration::from_secs(600),
+            doc_gc: false,
+        }
+    }
+
+    /// Let actors drain their mailboxes (single-threaded test runtime).
     async fn settle() {
-        for _ in 0..10 {
+        for _ in 0..20 {
             tokio::task::yield_now().await;
         }
     }
@@ -522,7 +821,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn single_flight_concurrent_loads_share_one_load() {
         let store = GatedStore::new();
-        let registry = Arc::new(DocRegistry::new(test_metrics()));
+        let registry = Arc::new(DocRegistry::new(test_metrics(), no_gc()));
         let loads = Arc::new(AtomicUsize::new(0));
 
         let docs = futures::future::join_all((0..8).map(|_| {
@@ -565,7 +864,7 @@ mod tests {
         // Enough injected failures that every concurrent caller's own
         // load attempt fails (waiters retry with their own load).
         let store = FailStore::new(8);
-        let registry = Arc::new(DocRegistry::new(test_metrics()));
+        let registry = Arc::new(DocRegistry::new(test_metrics(), no_gc()));
 
         let results = futures::future::join_all((0..8).map(|_| {
             let registry = registry.clone();
@@ -600,7 +899,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn evict_removes_slot_and_next_load_is_fresh() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new(test_metrics());
+        let registry = DocRegistry::new(test_metrics(), no_gc());
 
         let doc = registry
             .get_or_load("doc", || {
@@ -611,12 +910,7 @@ mod tests {
             .unwrap();
         doc.apply_update(&content_update("k", "v")).unwrap();
 
-        let outcome = registry
-            .evict("doc", |doc| async move {
-                doc.sync_kv().persist().await.unwrap();
-                EvictDecision::Evict
-            })
-            .await;
+        let outcome = registry.evict("doc").await;
         assert_eq!(outcome, EvictOutcome::Evicted);
         assert_eq!(registry.len(), 0);
         assert!(!registry.is_resident("doc"));
@@ -635,116 +929,238 @@ mod tests {
         assert_eq!(
             read_content(&reloaded, "k").as_deref(),
             Some("v"),
-            "the fresh instance must carry the final-flushed state"
+            "the eviction flush must land before the slot clears"
         );
     }
 
+    /// Race 1, ordering branch: an attach granted ahead of the Evict in
+    /// the mailbox makes the eviction refuse — the un-evict, decided
+    /// purely by message order.
     #[tokio::test(start_paused = true)]
-    async fn refused_evict_keeps_doc_resident() {
+    async fn attach_queued_before_evict_wins_and_unevicts() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new(test_metrics());
+        let registry = Arc::new(DocRegistry::new(test_metrics(), no_gc()));
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
 
-        let doc = registry
-            .get_or_load("doc", || {
-                let store = store.clone();
-                async move { load_doc(&store, "doc").await }
-            })
-            .await
-            .unwrap();
+        let doc = registry.get_or_load("doc", loader).await.unwrap();
 
-        let outcome = registry
-            .evict("doc", |_doc| async move { EvictDecision::Refuse })
-            .await;
-        assert_eq!(outcome, EvictOutcome::Refused);
-        assert_eq!(registry.len(), 1);
+        // The Attach message is enqueued eagerly when the future is
+        // created, so it sits in the mailbox ahead of the Evict sent
+        // below — the exact interleaving that used to orphan a doc.
+        let resident = registry.peek_resident("doc").unwrap();
+        let attach_fut = resident.handle.attach(AttachKind::Socket, &resident.doc);
 
-        let again = registry
-            .get_or_load("doc", || {
-                let store = store.clone();
-                async move { load_doc(&store, "doc").await }
-            })
-            .await
-            .unwrap();
-        assert!(
-            Arc::ptr_eq(&doc, &again),
-            "a refused eviction must keep the same instance"
+        let outcome = registry.evict("doc").await;
+        assert_eq!(
+            outcome,
+            EvictOutcome::Refused,
+            "an attach queued ahead of the eviction must refuse it"
         );
+
+        let guard = attach_fut.await.expect("the queued attach must be granted");
+        assert!(
+            Arc::ptr_eq(&doc, guard.doc()),
+            "the un-evicted doc must be the same instance"
+        );
+
+        // The surviving attachment's writes reach the store on release.
+        guard.doc().apply_update(&content_update("k", "v")).unwrap();
+        drop(guard);
+        settle().await;
+        assert_eq!(registry.evict("doc").await, EvictOutcome::Evicted);
+        let reloaded = registry.get_or_load("doc", loader).await.unwrap();
+        assert_eq!(read_content(&reloaded, "k").as_deref(), Some("v"));
     }
 
-    /// Race 2 (reload racing the final flush) at registry level: a load
-    /// racing an eviction must block until the eviction's final persist is
-    /// on the store, and must then observe the flushed bytes.
+    /// Races 1 (queue branch) and 2: an attach that arrives during an
+    /// eviction waits on the slot mutex until the final persist is on the
+    /// store, then loads a fresh instance carrying the flushed state.
     #[tokio::test(start_paused = true)]
-    async fn evict_holds_slot_against_concurrent_load_until_final_persist() {
+    async fn attach_during_evict_waits_for_fresh_instance_with_flushed_state() {
         let store = GatedStore::new();
-        let registry = Arc::new(DocRegistry::new(test_metrics()));
-
-        let doc = registry
-            .get_or_load("doc", || {
+        let registry = Arc::new(DocRegistry::new(test_metrics(), no_gc()));
+        let loader = {
+            let store = store.clone();
+            move || {
                 let store = store.clone();
                 async move { load_doc(&store, "doc").await }
-            })
-            .await
-            .unwrap();
+            }
+        };
+
+        let doc = registry.get_or_load("doc", loader.clone()).await.unwrap();
         doc.apply_update(&content_update("k", "v")).unwrap();
         drop(doc);
 
         store.close_gate();
-
-        let evict_handle = tokio::spawn({
+        let evict = tokio::spawn({
             let registry = registry.clone();
+            async move { registry.evict("doc").await }
+        });
+        // Let the eviction reach the gated final PUT.
+        settle().await;
+
+        let attach = tokio::spawn({
+            let registry = registry.clone();
+            let loader = loader.clone();
             async move {
                 registry
-                    .evict("doc", |doc| async move {
-                        doc.sync_kv().persist().await.unwrap();
-                        EvictDecision::Evict
-                    })
+                    .attach("doc", AttachKind::Socket, loader)
                     .await
+                    .unwrap()
             }
         });
-        // Let the eviction reach the gated PUT.
-        for _ in 0..20 {
-            tokio::task::yield_now().await;
-        }
-
-        let load_handle = tokio::spawn({
-            let registry = registry.clone();
-            let store = store.clone();
-            async move {
-                registry
-                    .get_or_load("doc", move || {
-                        let store = store.clone();
-                        async move { load_doc(&store, "doc").await }
-                    })
-                    .await
-            }
-        });
-        for _ in 0..20 {
-            tokio::task::yield_now().await;
-        }
+        settle().await;
         assert!(
-            !evict_handle.is_finished(),
+            !evict.is_finished(),
             "eviction must be parked on the gated final persist"
         );
         assert!(
-            !load_handle.is_finished(),
-            "a racing load must wait for the final persist, not read a stale snapshot"
+            !attach.is_finished(),
+            "a racing attach must wait for the final persist, not read stale bytes"
         );
 
-        store.release(1);
-        assert_eq!(evict_handle.await.unwrap(), EvictOutcome::Evicted);
-        let reloaded = load_handle.await.unwrap().unwrap();
+        store.open_gate();
+        assert_eq!(evict.await.unwrap(), EvictOutcome::Evicted);
+        let guard = attach.await.unwrap();
         assert_eq!(
-            read_content(&reloaded, "k").as_deref(),
+            read_content(guard.doc(), "k").as_deref(),
             Some("v"),
-            "the racing load must observe the final flush"
+            "the racing attach must observe the eviction's final flush"
         );
+    }
+
+    /// Race 3: a task holding a guard dies; RAII detach releases the
+    /// count and the doc becomes evictable — dead connections cannot pin.
+    #[tokio::test(start_paused = true)]
+    async fn dead_socket_task_cannot_pin_doc() {
+        let store = MemoryStore::new();
+        let registry = Arc::new(DocRegistry::new(test_metrics(), no_gc()));
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
+
+        let guard = registry
+            .attach("doc", AttachKind::Socket, loader)
+            .await
+            .unwrap();
+        let holder = tokio::spawn(async move {
+            let _guard = guard;
+            std::future::pending::<()>().await;
+        });
+        settle().await;
+        assert_eq!(
+            registry.evict("doc").await,
+            EvictOutcome::Refused,
+            "a live holder must pin the doc"
+        );
+
+        holder.abort();
+        settle().await;
+        assert_eq!(
+            registry.evict("doc").await,
+            EvictOutcome::Evicted,
+            "an aborted holder's guard must release its attachment"
+        );
+    }
+
+    /// Race 4: the last detach flushes immediately — no throttle wait, no
+    /// time advance — because the machine may be suspended any moment
+    /// after the doc goes quiet.
+    #[tokio::test(start_paused = true)]
+    async fn idle_entry_flush_beats_park_window() {
+        let metrics = test_metrics();
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(metrics.clone(), no_gc());
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
+
+        let guard = registry
+            .attach("doc", AttachKind::Socket, loader)
+            .await
+            .unwrap();
+        guard.doc().apply_update(&content_update("k", "v")).unwrap();
+        drop(guard);
+
+        // No sleeps: virtual time must not advance, so only the
+        // idle-entry flush can explain bytes reaching the store.
+        settle().await;
+        assert!(
+            store.get_bytes("doc/data.ysweet").is_some(),
+            "idle entry must flush before the park window opens"
+        );
+        assert_eq!(
+            metrics
+                .doc_dirty_at_drain_total
+                .with_label_values(&[])
+                .get(),
+            1.0,
+            "the dirty-at-drain metric moves to the actor's idle entry"
+        );
+    }
+
+    /// The one timer test: the idle deadline itself sends the eviction
+    /// request. Everything else drives eviction explicitly.
+    #[tokio::test(start_paused = true)]
+    async fn idle_deadline_timer_sends_evict() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(
+            test_metrics(),
+            LifecycleConfig {
+                checkpoint_freq: Duration::from_millis(10),
+                doc_gc: true,
+            },
+        );
+
+        registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .unwrap();
+        assert!(registry.is_resident("doc"));
+
+        // Past the 2×checkpoint_freq deadline plus sweeper handoff.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !registry.is_resident("doc"),
+            "an idle doc must age out via the deadline"
+        );
+        assert_eq!(registry.len(), 0, "eviction must reclaim the slot");
+    }
+
+    /// With doc_gc off the deadline never arms and idle docs stay.
+    #[tokio::test(start_paused = true)]
+    async fn doc_gc_off_never_evicts() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(
+            test_metrics(),
+            LifecycleConfig {
+                checkpoint_freq: Duration::from_millis(10),
+                doc_gc: false,
+            },
+        );
+        registry
+            .get_or_load("doc", || {
+                let store = store.clone();
+                async move { load_doc(&store, "doc").await }
+            })
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        assert!(registry.is_resident("doc"));
     }
 
     #[tokio::test(start_paused = true)]
     async fn slot_count_returns_to_zero_after_load_evict_cycles() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new(test_metrics());
+        let registry = DocRegistry::new(test_metrics(), no_gc());
 
         for round in 0..10 {
             registry
@@ -755,10 +1171,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(registry.len(), 1);
-            let outcome = registry
-                .evict("doc", |_doc| async move { EvictDecision::Evict })
-                .await;
-            assert_eq!(outcome, EvictOutcome::Evicted);
+            assert_eq!(registry.evict("doc").await, EvictOutcome::Evicted);
             assert_eq!(
                 registry.len(),
                 0,
@@ -770,7 +1183,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn attach_guard_drop_sends_detach_and_count_reaches_zero() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new(test_metrics());
+        let registry = DocRegistry::new(test_metrics(), no_gc());
         let loader = || {
             let store = store.clone();
             async move { load_doc(&store, "doc").await }
@@ -787,7 +1200,6 @@ mod tests {
         settle().await;
 
         let resident = registry.peek_resident("doc").unwrap();
-        assert_eq!(resident.handle.connections(), 2);
         assert_eq!(
             *resident.handle.state().borrow(),
             LifecycleState::Active { connections: 2 }
@@ -795,18 +1207,20 @@ mod tests {
 
         drop(socket_guard);
         settle().await;
-        assert_eq!(resident.handle.connections(), 1);
+        assert_eq!(
+            *resident.handle.state().borrow(),
+            LifecycleState::Active { connections: 1 }
+        );
 
         drop(http_guard);
         settle().await;
-        assert_eq!(resident.handle.connections(), 0);
         assert_eq!(*resident.handle.state().borrow(), LifecycleState::Idle);
     }
 
     #[tokio::test(start_paused = true)]
     async fn attach_kinds_tracked_independently() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new(test_metrics());
+        let registry = DocRegistry::new(test_metrics(), no_gc());
         let loader = || {
             let store = store.clone();
             async move { load_doc(&store, "doc").await }
@@ -844,7 +1258,7 @@ mod tests {
     async fn transition_metrics_emitted() {
         let metrics = test_metrics();
         let store = MemoryStore::new();
-        let registry = DocRegistry::new(metrics.clone());
+        let registry = DocRegistry::new(metrics.clone(), no_gc());
         let loader = || {
             let store = store.clone();
             async move { load_doc(&store, "doc").await }
@@ -868,84 +1282,9 @@ mod tests {
         drop(guard);
         settle().await;
         assert_eq!(transitions("active", "idle"), 1.0, "last detach");
-    }
 
-    /// The step-3 shippability contract: a guard holds exactly one strong
-    /// awareness clone, so the strong-count probes (still authoritative
-    /// for eviction) see attachments exactly as before the swap.
-    #[tokio::test(start_paused = true)]
-    async fn guard_holds_awareness_so_strong_count_agrees() {
-        let store = MemoryStore::new();
-        let registry = DocRegistry::new(test_metrics());
-        let loader = || {
-            let store = store.clone();
-            async move { load_doc(&store, "doc").await }
-        };
-
-        let doc = registry.get_or_load("doc", loader).await.unwrap();
-        let probe = Arc::downgrade(&doc.awareness());
-        assert_eq!(probe.strong_count(), 1, "baseline: only the doc's own ref");
-
-        let guard = registry
-            .attach("doc", AttachKind::Socket, loader)
-            .await
-            .unwrap();
-        assert_eq!(probe.strong_count(), 2, "a guard is one awareness ref");
-
-        drop(guard);
-        assert_eq!(probe.strong_count(), 1, "detach releases the ref");
-    }
-
-    /// A scripted attach/detach sequence during which the shadow
-    /// comparison (explicit counts vs strong-count probe) must never
-    /// disagree once the actor has drained its mailbox. This is the
-    /// in-vitro version of the soak the GC worker runs in production.
-    #[tokio::test(start_paused = true)]
-    async fn shadow_mismatch_metric_zero_across_scripted_sequence() {
-        let store = MemoryStore::new();
-        let registry = DocRegistry::new(test_metrics());
-        let loader = || {
-            let store = store.clone();
-            async move { load_doc(&store, "doc").await }
-        };
-
-        let check = |step: &str| {
-            let resident = registry.peek_resident("doc").unwrap();
-            assert!(
-                !shadow_accounting_disagrees(&resident),
-                "shadow accounting disagreed after: {step}"
-            );
-        };
-
-        registry.get_or_load("doc", loader).await.unwrap();
-        settle().await;
-        check("load without attach");
-
-        let socket = registry
-            .attach("doc", AttachKind::Socket, loader)
-            .await
-            .unwrap();
-        settle().await;
-        check("socket attach");
-
-        let subdoc = registry
-            .attach("doc", AttachKind::Subdoc, loader)
-            .await
-            .unwrap();
-        let http = registry
-            .attach("doc", AttachKind::Http, loader)
-            .await
-            .unwrap();
-        settle().await;
-        check("three concurrent kinds");
-
-        drop(http);
-        drop(socket);
-        settle().await;
-        check("partial detach");
-
-        drop(subdoc);
-        settle().await;
-        check("fully idle");
+        assert_eq!(registry.evict("doc").await, EvictOutcome::Evicted);
+        assert_eq!(transitions("idle", "evicting"), 1.0);
+        assert_eq!(transitions("evicting", "gone"), 1.0);
     }
 }

--- a/crates/relay/src/doc_lifecycle.rs
+++ b/crates/relay/src/doc_lifecycle.rs
@@ -18,8 +18,246 @@
 use dashmap::DashMap;
 use std::future::Future;
 use std::sync::{Arc, RwLock};
-use tokio::sync::Mutex as AsyncMutex;
-use y_sweet_core::doc_sync::DocWithSyncKv;
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    watch, Mutex as AsyncMutex,
+};
+use y_sweet_core::{
+    doc_sync::DocWithSyncKv, metrics::RelayMetrics, sync::awareness::Awareness, sync_kv::SyncKv,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachKind {
+    Socket,
+    Http,
+    Subdoc,
+}
+
+impl AttachKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            AttachKind::Socket => "socket",
+            AttachKind::Http => "http",
+            AttachKind::Subdoc => "subdoc",
+        }
+    }
+}
+
+/// The actor-side view of a doc's lifecycle. `Loading` is a registry-slot
+/// phase, so the observable states start at the actor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleState {
+    Active { connections: usize },
+    Idle,
+}
+
+/// Mailbox messages for a doc's lifecycle actor. In the shadow-accounting
+/// phase the actor only maintains explicit connection counts; eviction
+/// authority moves here in a later migration step.
+pub enum DocMsg {
+    Attach {
+        kind: AttachKind,
+    },
+    Detach {
+        kind: AttachKind,
+    },
+    #[allow(dead_code)] // authoritative from the persistence step onward
+    Dirty,
+}
+
+/// Handle to a doc's lifecycle actor. Cloned into the registry slot and
+/// every guard; the actor exits when the last sender is gone.
+#[derive(Clone)]
+pub struct DocHandle {
+    tx: UnboundedSender<DocMsg>,
+    state: watch::Receiver<LifecycleState>,
+}
+
+impl DocHandle {
+    /// Attach to the doc: counts the attachment and returns the RAII
+    /// guard carrying the data-plane handles. The guard holds a strong
+    /// awareness clone so the (still-authoritative) strong-count liveness
+    /// probes see guards exactly as they saw raw awareness refs.
+    pub fn attach(&self, kind: AttachKind, doc: &Arc<DocWithSyncKv>) -> AttachGuard {
+        // Unbounded send: never blocks; failure means the actor is gone,
+        // in which case there is no count left to maintain.
+        let _ = self.tx.send(DocMsg::Attach { kind });
+        AttachGuard {
+            kind,
+            awareness: doc.awareness(),
+            doc: Arc::clone(doc),
+            tx: self.tx.clone(),
+        }
+    }
+
+    /// Explicit connection count as the actor sees it. Shadow-accounting
+    /// accessor: exists so the GC worker can compare counts against the
+    /// strong-count probe; deleted when eviction flips to the counts.
+    pub fn connections(&self) -> usize {
+        match *self.state.borrow() {
+            LifecycleState::Active { connections } => connections,
+            LifecycleState::Idle => 0,
+        }
+    }
+
+    pub fn state(&self) -> watch::Receiver<LifecycleState> {
+        self.state.clone()
+    }
+}
+
+/// RAII attachment to a live doc. Dropping it detaches: the send is
+/// unbounded and infallible from sync contexts, so accounting cannot be
+/// lost by a caller forgetting a teardown path.
+pub struct AttachGuard {
+    kind: AttachKind,
+    doc: Arc<DocWithSyncKv>,
+    /// Strong awareness clone, held for the shadow-accounting phase: the
+    /// strong-count probes must see one ref per attachment, exactly as
+    /// they saw the raw clones this guard replaces.
+    awareness: Arc<RwLock<Awareness>>,
+    tx: UnboundedSender<DocMsg>,
+}
+
+impl AttachGuard {
+    pub fn awareness(&self) -> Arc<RwLock<Awareness>> {
+        Arc::clone(&self.awareness)
+    }
+
+    pub fn sync_kv(&self) -> Arc<SyncKv> {
+        self.doc.sync_kv()
+    }
+
+    pub fn doc(&self) -> &Arc<DocWithSyncKv> {
+        &self.doc
+    }
+}
+
+impl Drop for AttachGuard {
+    fn drop(&mut self) {
+        let _ = self.tx.send(DocMsg::Detach { kind: self.kind });
+    }
+}
+
+/// A resident doc: the instance plus its lifecycle actor's handle.
+#[derive(Clone)]
+pub(crate) struct Resident {
+    pub doc: Arc<DocWithSyncKv>,
+    pub handle: DocHandle,
+}
+
+/// The per-doc lifecycle actor. In this phase it is a pure connection
+/// ledger: it processes Attach/Detach in mailbox order, publishes the
+/// resulting state on a watch channel, and emits transition metrics.
+struct DocActor {
+    doc_id: String,
+    mailbox: UnboundedReceiver<DocMsg>,
+    state_tx: watch::Sender<LifecycleState>,
+    sockets: usize,
+    https: usize,
+    subdocs: usize,
+    metrics: Arc<RelayMetrics>,
+}
+
+impl DocActor {
+    fn spawn(doc_id: String, metrics: Arc<RelayMetrics>) -> DocHandle {
+        let (tx, mailbox) = unbounded_channel();
+        let (state_tx, state_rx) = watch::channel(LifecycleState::Idle);
+        metrics.record_lifecycle_transition("loading", "idle");
+        let actor = DocActor {
+            doc_id,
+            mailbox,
+            state_tx,
+            sockets: 0,
+            https: 0,
+            subdocs: 0,
+            metrics,
+        };
+        tokio::spawn(actor.run());
+        DocHandle {
+            tx,
+            state: state_rx,
+        }
+    }
+
+    fn connections(&self) -> usize {
+        self.sockets + self.https + self.subdocs
+    }
+
+    async fn run(mut self) {
+        // The slot holds one sender and each guard holds one; the actor
+        // ends when the doc is evicted and the last guard is gone.
+        while let Some(msg) = self.mailbox.recv().await {
+            match msg {
+                DocMsg::Attach { kind } => {
+                    let was = self.connections();
+                    match kind {
+                        AttachKind::Socket => self.sockets += 1,
+                        AttachKind::Http => self.https += 1,
+                        AttachKind::Subdoc => self.subdocs += 1,
+                    }
+                    if was == 0 {
+                        self.metrics.record_lifecycle_transition("idle", "active");
+                    }
+                    self.publish();
+                    tracing::debug!(
+                        doc_id = %self.doc_id,
+                        kind = kind.as_str(),
+                        connections = self.connections(),
+                        "attach"
+                    );
+                }
+                DocMsg::Detach { kind } => {
+                    let counter = match kind {
+                        AttachKind::Socket => &mut self.sockets,
+                        AttachKind::Http => &mut self.https,
+                        AttachKind::Subdoc => &mut self.subdocs,
+                    };
+                    debug_assert!(*counter > 0, "detach without matching attach");
+                    *counter = counter.saturating_sub(1);
+                    if self.connections() == 0 {
+                        self.metrics.record_lifecycle_transition("active", "idle");
+                    }
+                    self.publish();
+                    tracing::debug!(
+                        doc_id = %self.doc_id,
+                        kind = kind.as_str(),
+                        connections = self.connections(),
+                        "detach"
+                    );
+                }
+                DocMsg::Dirty => {}
+            }
+        }
+    }
+
+    fn publish(&self) {
+        let state = match self.connections() {
+            0 => LifecycleState::Idle,
+            n => LifecycleState::Active { connections: n },
+        };
+        let _ = self.state_tx.send(state);
+    }
+}
+
+/// A bare actor handle for harnesses that drive the socket path without
+/// a registry (see `server.rs`'s in-memory socket tests).
+#[cfg(test)]
+pub(crate) fn test_actor_handle(doc_id: &str, metrics: Arc<RelayMetrics>) -> DocHandle {
+    DocActor::spawn(doc_id.to_string(), metrics)
+}
+
+/// The shadow-accounting comparison: does the explicit connection count
+/// agree with the awareness strong-count probe? A single-instant mismatch
+/// can be an attach/detach caught mid-flight (the guard's awareness clone
+/// and its mailbox message are not atomic), so callers only record a
+/// mismatch after it persists across two consecutive checks.
+/// Returns whether this check disagreed.
+pub(crate) fn shadow_accounting_disagrees(resident: &Resident) -> bool {
+    let probe = Arc::downgrade(&resident.doc.awareness());
+    let strong_alive = probe.strong_count() > 1;
+    let counted_alive = resident.handle.connections() > 0;
+    strong_alive != counted_alive
+}
 
 /// What an evictor decided after inspecting the doc under the slot lock.
 pub enum EvictDecision {
@@ -41,7 +279,7 @@ pub enum EvictOutcome {
 }
 
 struct SlotState {
-    doc: Option<Arc<DocWithSyncKv>>,
+    doc: Option<Resident>,
     /// Set exactly once, under the slot mutex, when the slot is removed
     /// from the map. Tells mutex waiters their slot is dead.
     defunct: bool,
@@ -64,23 +302,46 @@ impl Slot {
     }
 }
 
-#[derive(Default)]
 pub struct DocRegistry {
     slots: DashMap<String, Arc<Slot>>,
+    metrics: Arc<RelayMetrics>,
 }
 
 impl DocRegistry {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(metrics: Arc<RelayMetrics>) -> Self {
+        Self {
+            slots: DashMap::new(),
+            metrics,
+        }
     }
 
     /// Lock-free view of a resident doc. During an eviction the doc is
     /// already withdrawn from the slot, so a peek misses and the caller
     /// serializes through `get_or_load`.
     pub fn peek(&self, doc_id: &str) -> Option<Arc<DocWithSyncKv>> {
+        self.peek_resident(doc_id).map(|r| r.doc)
+    }
+
+    pub(crate) fn peek_resident(&self, doc_id: &str) -> Option<Resident> {
         let slot = self.slots.get(doc_id)?;
         let state = slot.state.read().unwrap();
         state.doc.clone()
+    }
+
+    /// Load (if needed) and attach in one step: the returned guard is the
+    /// unit of explicit connection accounting.
+    pub async fn attach<F, Fut>(
+        &self,
+        doc_id: &str,
+        kind: AttachKind,
+        loader: F,
+    ) -> anyhow::Result<AttachGuard>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
+    {
+        let resident = self.get_or_load_resident(doc_id, loader).await?;
+        Ok(resident.handle.attach(kind, &resident.doc))
     }
 
     pub fn is_resident(&self, doc_id: &str) -> bool {
@@ -95,6 +356,7 @@ impl DocRegistry {
         self.slots
             .iter()
             .filter_map(|entry| entry.value().state.read().unwrap().doc.clone())
+            .map(|resident| resident.doc)
             .collect()
     }
 
@@ -122,13 +384,25 @@ impl DocRegistry {
         F: Fn() -> Fut,
         Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
     {
+        Ok(self.get_or_load_resident(doc_id, loader).await?.doc)
+    }
+
+    async fn get_or_load_resident<F, Fut>(
+        &self,
+        doc_id: &str,
+        loader: F,
+    ) -> anyhow::Result<Resident>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = anyhow::Result<DocWithSyncKv>>,
+    {
         loop {
             // Fast path: no slot mutex. An evicting doc is already
             // withdrawn from the slot state, so this cannot observe one.
             if let Some(slot) = self.slots.get(doc_id) {
-                let doc = slot.state.read().unwrap().doc.clone();
-                if let Some(doc) = doc {
-                    return Ok(doc);
+                let resident = slot.state.read().unwrap().doc.clone();
+                if let Some(resident) = resident {
+                    return Ok(resident);
                 }
             }
 
@@ -150,16 +424,19 @@ impl DocRegistry {
                     // waited; start over from the map.
                     continue;
                 }
-                if let Some(doc) = state.doc.clone() {
-                    return Ok(doc);
+                if let Some(resident) = state.doc.clone() {
+                    return Ok(resident);
                 }
             }
 
             match loader().await {
                 Ok(doc) => {
-                    let doc = Arc::new(doc);
-                    slot.state.write().unwrap().doc = Some(Arc::clone(&doc));
-                    return Ok(doc);
+                    let resident = Resident {
+                        doc: Arc::new(doc),
+                        handle: DocActor::spawn(doc_id.to_string(), self.metrics.clone()),
+                    };
+                    slot.state.write().unwrap().doc = Some(resident.clone());
+                    return Ok(resident);
                 }
                 Err(err) => {
                     slot.state.write().unwrap().defunct = true;
@@ -186,20 +463,20 @@ impl DocRegistry {
         };
         let _guard = slot.mu.lock().await;
 
-        let doc = {
+        let resident = {
             let mut state = slot.state.write().unwrap();
             if state.defunct {
                 return EvictOutcome::Absent;
             }
             match state.doc.take() {
-                Some(doc) => doc,
+                Some(resident) => resident,
                 None => return EvictOutcome::Absent,
             }
         };
 
-        match evictor(Arc::clone(&doc)).await {
+        match evictor(Arc::clone(&resident.doc)).await {
             EvictDecision::Refuse => {
-                slot.state.write().unwrap().doc = Some(doc);
+                slot.state.write().unwrap().doc = Some(resident);
                 EvictOutcome::Refused
             }
             EvictDecision::Evict => {
@@ -218,6 +495,17 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use y_sweet_core::store::{memory::MemoryStore, Store};
 
+    fn test_metrics() -> Arc<RelayMetrics> {
+        RelayMetrics::new_with_registry(&prometheus::Registry::new()).unwrap()
+    }
+
+    /// Let the actor drain its mailbox (single-threaded test runtime).
+    async fn settle() {
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+    }
+
     async fn load_doc<S: Store + Clone + 'static>(
         store: &S,
         doc_id: &str,
@@ -234,7 +522,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn single_flight_concurrent_loads_share_one_load() {
         let store = GatedStore::new();
-        let registry = Arc::new(DocRegistry::new());
+        let registry = Arc::new(DocRegistry::new(test_metrics()));
         let loads = Arc::new(AtomicUsize::new(0));
 
         let docs = futures::future::join_all((0..8).map(|_| {
@@ -277,7 +565,7 @@ mod tests {
         // Enough injected failures that every concurrent caller's own
         // load attempt fails (waiters retry with their own load).
         let store = FailStore::new(8);
-        let registry = Arc::new(DocRegistry::new());
+        let registry = Arc::new(DocRegistry::new(test_metrics()));
 
         let results = futures::future::join_all((0..8).map(|_| {
             let registry = registry.clone();
@@ -312,7 +600,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn evict_removes_slot_and_next_load_is_fresh() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new();
+        let registry = DocRegistry::new(test_metrics());
 
         let doc = registry
             .get_or_load("doc", || {
@@ -354,7 +642,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn refused_evict_keeps_doc_resident() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new();
+        let registry = DocRegistry::new(test_metrics());
 
         let doc = registry
             .get_or_load("doc", || {
@@ -389,7 +677,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn evict_holds_slot_against_concurrent_load_until_final_persist() {
         let store = GatedStore::new();
-        let registry = Arc::new(DocRegistry::new());
+        let registry = Arc::new(DocRegistry::new(test_metrics()));
 
         let doc = registry
             .get_or_load("doc", || {
@@ -456,7 +744,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn slot_count_returns_to_zero_after_load_evict_cycles() {
         let store = MemoryStore::new();
-        let registry = DocRegistry::new();
+        let registry = DocRegistry::new(test_metrics());
 
         for round in 0..10 {
             registry
@@ -477,5 +765,187 @@ mod tests {
                 "round {round}: eviction must fully reclaim the slot"
             );
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn attach_guard_drop_sends_detach_and_count_reaches_zero() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(test_metrics());
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
+
+        let socket_guard = registry
+            .attach("doc", AttachKind::Socket, loader)
+            .await
+            .unwrap();
+        let http_guard = registry
+            .attach("doc", AttachKind::Http, loader)
+            .await
+            .unwrap();
+        settle().await;
+
+        let resident = registry.peek_resident("doc").unwrap();
+        assert_eq!(resident.handle.connections(), 2);
+        assert_eq!(
+            *resident.handle.state().borrow(),
+            LifecycleState::Active { connections: 2 }
+        );
+
+        drop(socket_guard);
+        settle().await;
+        assert_eq!(resident.handle.connections(), 1);
+
+        drop(http_guard);
+        settle().await;
+        assert_eq!(resident.handle.connections(), 0);
+        assert_eq!(*resident.handle.state().borrow(), LifecycleState::Idle);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn attach_kinds_tracked_independently() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(test_metrics());
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
+
+        let subdoc_guard = registry
+            .attach("doc", AttachKind::Subdoc, loader)
+            .await
+            .unwrap();
+
+        // Socket attachments come and go; the subdoc pin must keep the
+        // doc Active throughout.
+        for _ in 0..3 {
+            let socket_guard = registry
+                .attach("doc", AttachKind::Socket, loader)
+                .await
+                .unwrap();
+            drop(socket_guard);
+            settle().await;
+            let resident = registry.peek_resident("doc").unwrap();
+            assert_eq!(
+                *resident.handle.state().borrow(),
+                LifecycleState::Active { connections: 1 },
+                "the subdoc pin alone must keep the doc active"
+            );
+        }
+
+        drop(subdoc_guard);
+        settle().await;
+        let resident = registry.peek_resident("doc").unwrap();
+        assert_eq!(*resident.handle.state().borrow(), LifecycleState::Idle);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transition_metrics_emitted() {
+        let metrics = test_metrics();
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(metrics.clone());
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
+
+        let transitions = |from: &str, to: &str| {
+            metrics
+                .doc_lifecycle_transitions_total
+                .with_label_values(&[from, to])
+                .get()
+        };
+
+        let guard = registry
+            .attach("doc", AttachKind::Socket, loader)
+            .await
+            .unwrap();
+        settle().await;
+        assert_eq!(transitions("loading", "idle"), 1.0, "actor birth");
+        assert_eq!(transitions("idle", "active"), 1.0, "first attach");
+
+        drop(guard);
+        settle().await;
+        assert_eq!(transitions("active", "idle"), 1.0, "last detach");
+    }
+
+    /// The step-3 shippability contract: a guard holds exactly one strong
+    /// awareness clone, so the strong-count probes (still authoritative
+    /// for eviction) see attachments exactly as before the swap.
+    #[tokio::test(start_paused = true)]
+    async fn guard_holds_awareness_so_strong_count_agrees() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(test_metrics());
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
+
+        let doc = registry.get_or_load("doc", loader).await.unwrap();
+        let probe = Arc::downgrade(&doc.awareness());
+        assert_eq!(probe.strong_count(), 1, "baseline: only the doc's own ref");
+
+        let guard = registry
+            .attach("doc", AttachKind::Socket, loader)
+            .await
+            .unwrap();
+        assert_eq!(probe.strong_count(), 2, "a guard is one awareness ref");
+
+        drop(guard);
+        assert_eq!(probe.strong_count(), 1, "detach releases the ref");
+    }
+
+    /// A scripted attach/detach sequence during which the shadow
+    /// comparison (explicit counts vs strong-count probe) must never
+    /// disagree once the actor has drained its mailbox. This is the
+    /// in-vitro version of the soak the GC worker runs in production.
+    #[tokio::test(start_paused = true)]
+    async fn shadow_mismatch_metric_zero_across_scripted_sequence() {
+        let store = MemoryStore::new();
+        let registry = DocRegistry::new(test_metrics());
+        let loader = || {
+            let store = store.clone();
+            async move { load_doc(&store, "doc").await }
+        };
+
+        let check = |step: &str| {
+            let resident = registry.peek_resident("doc").unwrap();
+            assert!(
+                !shadow_accounting_disagrees(&resident),
+                "shadow accounting disagreed after: {step}"
+            );
+        };
+
+        registry.get_or_load("doc", loader).await.unwrap();
+        settle().await;
+        check("load without attach");
+
+        let socket = registry
+            .attach("doc", AttachKind::Socket, loader)
+            .await
+            .unwrap();
+        settle().await;
+        check("socket attach");
+
+        let subdoc = registry
+            .attach("doc", AttachKind::Subdoc, loader)
+            .await
+            .unwrap();
+        let http = registry
+            .attach("doc", AttachKind::Http, loader)
+            .await
+            .unwrap();
+        settle().await;
+        check("three concurrent kinds");
+
+        drop(http);
+        drop(socket);
+        settle().await;
+        check("partial detach");
+
+        drop(subdoc);
+        settle().await;
+        check("fully idle");
     }
 }

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod cli;
 pub mod convert;
 pub mod doc_inspect;
+pub mod doc_lifecycle;
 pub mod doc_restore;
 pub mod doc_versions;
 pub mod migrations;

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -9,4 +9,6 @@ pub mod migrations;
 pub mod server;
 pub mod stores;
 pub mod subdocs;
+#[cfg(test)]
+pub(crate) mod test_util;
 pub mod webhook;

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -984,12 +984,24 @@ async fn main() -> Result<()> {
             let signal = shutdown_signal().await;
 
             tracing::info!("Received {}, shutting down.", signal);
+            // Client-compatible drain: deployed clients stop retrying a
+            // dropped socket after a brief burst of refused attempts, so
+            // the close-to-exit window must stay well under a second.
+            //
+            // Beat 1: flush every dirty doc while sockets keep serving —
+            // the slow store work happens before any client notices.
+            server.flush_all_docs().await;
+            // Beat 2: cutover. Cancel the workers; their final persists
+            // cover only the delta written during the flush, so this is
+            // bounded by a handful of PUTs.
             token.cancel();
-
+            server.drain_doc_workers().await;
+            // Beat 3: exit now. Deliberately do NOT await the HTTP drain:
+            // a bound listener that refuses upgrades eats into the
+            // reconnect budget of every client it turns away.
+            main_handle.abort();
             if let Some(metrics_handle) = metrics_handle {
-                let _ = tokio::join!(main_handle, metrics_handle);
-            } else {
-                let _ = main_handle.await;
+                metrics_handle.abort();
             }
             tracing::info!("Server shut down.");
         }

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -991,9 +991,10 @@ async fn main() -> Result<()> {
             // Beat 1: flush every dirty doc while sockets keep serving —
             // the slow store work happens before any client notices.
             server.flush_all_docs().await;
-            // Beat 2: cutover. Cancel the workers; their final persists
-            // cover only the delta written during the flush, so this is
-            // bounded by a handful of PUTs.
+            // Beat 2: cutover. Close doc sockets and cancel the workers;
+            // their final persists cover only the delta written during
+            // the flush, so this is bounded by a handful of PUTs.
+            server.close_doc_sockets();
             token.cancel();
             server.drain_doc_workers().await;
             // Beat 3: exit now. Deliberately do NOT await the HTTP drain:

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -1,4 +1,4 @@
-use crate::doc_lifecycle::{AttachGuard, AttachKind, DocRegistry, EvictDecision, EvictOutcome};
+use crate::doc_lifecycle::{AttachGuard, AttachKind, DocRegistry, LifecycleConfig};
 use anyhow::{anyhow, Result};
 use axum::{
     body::Bytes,
@@ -235,8 +235,6 @@ pub struct Server {
     /// alone closes every doc WebSocket without stopping anything else, so
     /// shutdown can clear the sockets before axum's graceful drain starts.
     doc_close_token: CancellationToken,
-    /// Whether to garbage collect docs that are no longer in use.
-    doc_gc: bool,
     event_dispatcher: Option<Arc<dyn EventDispatcher>>,
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     metrics: Arc<RelayMetrics>,
@@ -292,7 +290,13 @@ impl Server {
         tracing::info!("Event dispatcher created successfully");
 
         Ok(Self {
-            registry: Arc::new(DocRegistry::new(metrics.clone())),
+            registry: Arc::new(DocRegistry::new(
+                metrics.clone(),
+                LifecycleConfig {
+                    checkpoint_freq,
+                    doc_gc,
+                },
+            )),
             doc_worker_tracker: TaskTracker::new(),
             store: store.map(Arc::new),
             checkpoint_freq,
@@ -301,7 +305,6 @@ impl Server {
             allowed_hosts,
             doc_close_token: cancellation_token.child_token(),
             cancellation_token,
-            doc_gc,
             event_dispatcher,
             sync_protocol_event_sender,
             metrics,
@@ -548,126 +551,9 @@ impl Server {
                 )
                 .instrument(span!(Level::INFO, "save_loop", doc_id=?doc_id)),
             );
-
-            if self.doc_gc {
-                self.doc_worker_tracker.spawn(
-                    Self::doc_gc_worker(
-                        self.registry.clone(),
-                        doc_id.clone(),
-                        checkpoint_freq,
-                        cancellation_token,
-                        self.metrics.clone(),
-                    )
-                    .instrument(span!(Level::INFO, "gc_loop", doc_id=?doc_id)),
-                );
-            }
         }
 
         Ok(dwskv)
-    }
-
-    async fn doc_gc_worker(
-        registry: Arc<DocRegistry>,
-        doc_id: String,
-        checkpoint_freq: Duration,
-        cancellation_token: CancellationToken,
-        metrics: Arc<RelayMetrics>,
-    ) {
-        let mut checkpoints_without_refs = 0;
-        let mut consecutive_shadow_mismatches = 0u32;
-
-        loop {
-            tokio::select! {
-                _ = tokio::time::sleep(checkpoint_freq) => {
-                    if let Some(resident) = registry.peek_resident(&doc_id) {
-                        // Shadow-accounting soak: the explicit counts must
-                        // agree with the strong-count probe before eviction
-                        // can flip to them. A single-tick disagreement can
-                        // be an attach/detach caught mid-flight, so only
-                        // two consecutive mismatched ticks count as drift.
-                        if crate::doc_lifecycle::shadow_accounting_disagrees(&resident) {
-                            consecutive_shadow_mismatches += 1;
-                            if consecutive_shadow_mismatches >= 2 {
-                                metrics.record_lifecycle_accounting_mismatch();
-                                tracing::warn!(
-                                    doc_id = %doc_id,
-                                    connections = resident.handle.connections(),
-                                    "lifecycle shadow accounting mismatch: explicit counts disagree with the awareness strong-count probe"
-                                );
-                            }
-                        } else {
-                            consecutive_shadow_mismatches = 0;
-                        }
-
-                        let awareness = Arc::downgrade(&resident.doc.awareness());
-                        if awareness.strong_count() > 1 {
-                            checkpoints_without_refs = 0;
-                            tracing::debug!("doc is still alive - it has {} references", awareness.strong_count());
-                        } else {
-                            checkpoints_without_refs += 1;
-                            tracing::info!("doc has only one reference, candidate for GC. checkpoints_without_refs: {}", checkpoints_without_refs);
-                        }
-                    } else {
-                        break;
-                    }
-
-                    if checkpoints_without_refs >= 2 {
-                        // Eviction runs under the registry's slot lock: a
-                        // loader either finds the doc resident or waits
-                        // until the store already holds the final flush.
-                        let outcome = registry.evict(&doc_id, |doc| async move {
-                            // A connection may have attached between the
-                            // idle checks and taking the slot lock; it
-                            // holds awareness refs. Un-evict rather than
-                            // orphan it on an instance the registry no
-                            // longer knows: an orphan's updates dispatch
-                            // only to its own instance and are invisible
-                            // to every later connection.
-                            let probe = Arc::downgrade(&doc.awareness());
-                            if probe.strong_count() > 1 {
-                                tracing::info!("attach raced GC; un-evicting doc");
-                                return EvictDecision::Refuse;
-                            }
-                            tracing::info!("GCing doc");
-                            // Compact PUD before shutdown: dedup ids, clear
-                            // ds. The mutations create tombstones which yrs
-                            // GC will clean up, and the update observer
-                            // marks SyncKv dirty so the compacted state
-                            // gets persisted.
-                            let result = doc.compact_user_data();
-                            if !result.is_empty() {
-                                tracing::debug!(
-                                    ids_removed = result.ids_removed,
-                                    ds_removed = result.ds_removed,
-                                    "Compacted PermanentUserData"
-                                );
-                            }
-                            // The final state must reach the store before
-                            // the slot lock releases: a reload racing a
-                            // fire-and-forget flush loads a stale snapshot
-                            // and its next persist rolls the doc back.
-                            if let Err(e) = doc.sync_kv().persist().await {
-                                tracing::error!(?e, "Error persisting during GC eviction");
-                            }
-                            doc.sync_kv().shutdown();
-                            EvictDecision::Evict
-                        }).await;
-
-                        match outcome {
-                            EvictOutcome::Refused => {
-                                checkpoints_without_refs = 0;
-                                continue;
-                            }
-                            EvictOutcome::Evicted | EvictOutcome::Absent => break,
-                        }
-                    }
-                }
-                _ = cancellation_token.cancelled() => {
-                    break;
-                }
-            };
-        }
-        tracing::info!("Exiting gc_loop");
     }
 
     async fn doc_persistence_worker(
@@ -1314,11 +1200,6 @@ async fn handle_socket_inner<S, T, E>(
 
     let send_clone = send.clone();
     let metrics_clone = metrics.clone();
-    // Held past the connection's lifetime: the awareness strong count tells
-    // the teardown whether this handler was the doc's last connection (the
-    // same liveness test the gc worker uses), and the flush needs the kv.
-    let awareness_probe = awareness.clone();
-    let sync_kv_flush = sync_kv.clone();
     let mut conn = DocConnection::new_with_expiration(
         awareness,
         authorization,
@@ -1452,24 +1333,12 @@ async fn handle_socket_inner<S, T, E>(
 
     metrics.record_websocket_close(close_reason);
 
-    // The park window (auto-suspend / auto-stop) opens when a doc's last
-    // socket drains, but the checkpoint throttle may still be holding
-    // changes — an unsignaled suspend would freeze them dirty. Flush now:
-    // it is the same PUT the throttle already owed, just earlier, and a
-    // no-op when clean. The guard (and its awareness ref) must drop before
-    // the probe: holders at this point are then the doc's DocWithSyncKv,
-    // this probe, and three per other live connection (DocConnection,
-    // guard, probe).
+    // Teardown is pure RAII: dropping the guard detaches this connection
+    // from the doc's lifecycle actor, and if it was the last one, the
+    // actor's idle-entry flush persists whatever the checkpoint throttle
+    // was still holding — before the machine's park window can open.
     drop(connection);
     drop(guard);
-    if Arc::strong_count(&awareness_probe) <= 2 {
-        if sync_kv_flush.is_dirty() {
-            metrics.record_doc_dirty_at_drain();
-        }
-        if let Err(e) = sync_kv_flush.persist().await {
-            tracing::error!(?e, doc_id = %doc_id, "Error persisting on last disconnect");
-        }
-    }
 }
 
 async fn check_store(
@@ -3326,7 +3195,7 @@ mod test {
         }
 
         #[tokio::test(start_paused = true)]
-        async fn held_awareness_ref_prevents_gc() {
+        async fn held_attach_guard_prevents_eviction_until_dropped() {
             let server = test_server(
                 None,
                 Duration::from_millis(10),
@@ -3336,13 +3205,23 @@ mod test {
             .await;
 
             let doc_id = server.create_doc().await.unwrap();
-            let _held = server.get_or_create_doc(&doc_id).await.unwrap().awareness();
+            let guard = server
+                .attach_doc(&doc_id, AttachKind::Socket, None, None)
+                .await
+                .unwrap();
 
-            // Many multiples of the two-probe GC cadence.
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            // Many multiples of the idle-deadline cadence.
+            tokio::time::sleep(Duration::from_millis(500)).await;
             assert!(
                 server.registry.is_resident(&doc_id),
-                "a held awareness ref is the current liveness contract; GC must not evict"
+                "a held attachment is the liveness contract; the doc must not evict"
+            );
+
+            drop(guard);
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            assert!(
+                !server.registry.is_resident(&doc_id),
+                "with the last attachment gone the idle deadline must evict"
             );
         }
 
@@ -3394,6 +3273,92 @@ mod test {
             assert!(
                 !server.registry.is_resident(parent_id),
                 "parent pin leaked after the last subdoc was evicted"
+            );
+        }
+
+        /// Race 6, explicit form: a live subdoc's parent pin must refuse
+        /// eviction, and releasing the last pin must make the parent
+        /// evictable — driven by explicit evicts, no timers.
+        #[tokio::test(start_paused = true)]
+        async fn parent_evicts_only_after_last_subdoc_detaches() {
+            use crate::doc_lifecycle::EvictOutcome;
+            let store = MemoryStore::new();
+            let server = test_server(
+                Some(Box::new(store.clone())),
+                Duration::from_secs(600),
+                false,
+                CancellationToken::new(),
+            )
+            .await;
+
+            server
+                .get_or_create_doc_with_channel("child-doc", Some("parent-doc".to_string()))
+                .await
+                .unwrap();
+            for _ in 0..20 {
+                tokio::task::yield_now().await;
+            }
+
+            assert_eq!(
+                server.registry.evict("parent-doc").await,
+                EvictOutcome::Refused,
+                "a live subdoc must pin its parent"
+            );
+
+            assert_eq!(
+                server.registry.evict("child-doc").await,
+                EvictOutcome::Evicted
+            );
+            // The child actor dropped its doc, releasing the Subdoc guard
+            // held by its event callback; the parent's detach follows.
+            for _ in 0..20 {
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(
+                server.registry.evict("parent-doc").await,
+                EvictOutcome::Evicted,
+                "the released pin must make the parent evictable"
+            );
+        }
+
+        /// Race 5 (the HTTP-writer park hole): an HTTP one-shot update is
+        /// an attach/detach cycle, so its detach is an idle entry and must
+        /// flush immediately — no checkpoint_freq wait, no time advance.
+        #[tokio::test(start_paused = true)]
+        async fn http_update_flushes_on_idle_entry() {
+            let store = MemoryStore::new();
+            let server = Arc::new(
+                test_server(
+                    Some(Box::new(store.clone())),
+                    // A throttle long enough that only an idle-entry flush
+                    // can explain bytes reaching the store.
+                    Duration::from_secs(600),
+                    false,
+                    CancellationToken::new(),
+                )
+                .await,
+            );
+
+            let doc_id = server.create_doc().await.unwrap();
+            update_doc_inner(
+                doc_id.clone(),
+                server.clone(),
+                Authorization::Full,
+                Bytes::from(content_update("k", "v")),
+            )
+            .await
+            .unwrap();
+
+            // Let the actor process the detach and run its flush; no
+            // virtual time may pass (sleeps would advance the throttle).
+            for _ in 0..50 {
+                tokio::task::yield_now().await;
+            }
+
+            let key = format!("{doc_id}/data.ysweet");
+            assert!(
+                store.get_bytes(&key).is_some(),
+                "an HTTP update must be flushed at idle entry, within the park window"
             );
         }
 
@@ -3560,8 +3525,11 @@ mod test {
                     .unwrap(),
             );
             let sync_kv = doc.sync_kv();
-            let handle = crate::doc_lifecycle::test_actor_handle("test_doc", metrics.clone());
-            let guard = handle.attach(crate::doc_lifecycle::AttachKind::Socket, &doc);
+            let handle = crate::doc_lifecycle::test_actor_handle(&doc, metrics.clone());
+            let guard = handle
+                .attach(crate::doc_lifecycle::AttachKind::Socket, &doc)
+                .await
+                .expect("fresh test actor must grant the attach");
 
             let task = tokio::spawn(handle_socket_inner(
                 sink_tx,
@@ -3674,8 +3642,13 @@ mod test {
             assert_eq!(closes(&harness.metrics, "server_shutdown"), 1.0);
         }
 
+        /// The socket-path half of race 4: the socket dying is the last
+        /// detach, which is an idle entry, which flushes — before the
+        /// park window can open. The flush now lives in the lifecycle
+        /// actor; the socket handler's only obligation is dropping its
+        /// guard.
         #[tokio::test(start_paused = true)]
-        async fn last_disconnect_flushes_dirty_doc() {
+        async fn idle_entry_flushes_dirty_doc() {
             let harness = spawn_socket(CancellationToken::new()).await;
 
             // Dirty the doc the way any metadata/content change would,
@@ -3696,9 +3669,15 @@ mod test {
                 .expect("read loop kept running after stream EOF")
                 .unwrap();
 
+            // The guard's detach and the actor's flush run after the
+            // socket task ends; let them settle without advancing time.
+            for _ in 0..50 {
+                tokio::task::yield_now().await;
+            }
+
             assert!(
                 !harness.sync_kv.is_dirty(),
-                "last disconnect must flush before the park window opens"
+                "idle entry must flush before the park window opens"
             );
             assert_eq!(
                 harness

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -1,4 +1,4 @@
-use crate::doc_lifecycle::{DocRegistry, EvictDecision, EvictOutcome};
+use crate::doc_lifecycle::{AttachGuard, AttachKind, DocRegistry, EvictDecision, EvictOutcome};
 use anyhow::{anyhow, Result};
 use axum::{
     body::Bytes,
@@ -22,11 +22,7 @@ use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::{
-    io::Write,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{io::Write, sync::Arc, time::Duration};
 use tempfile::NamedTempFile;
 use tokio::{
     net::TcpListener,
@@ -50,7 +46,6 @@ use y_sweet_core::{
     },
     metrics::RelayMetrics,
     store::Store,
-    sync::awareness::Awareness,
     sync_kv::SyncKv,
     webhook::WebhookConfig,
 };
@@ -297,7 +292,7 @@ impl Server {
         tracing::info!("Event dispatcher created successfully");
 
         Ok(Self {
-            registry: Arc::new(DocRegistry::new()),
+            registry: Arc::new(DocRegistry::new(metrics.clone())),
             doc_worker_tracker: TaskTracker::new(),
             store: store.map(Arc::new),
             checkpoint_freq,
@@ -444,12 +439,16 @@ impl Server {
             .unwrap_or_else(|| doc_id.to_string());
 
         // If this doc routes to a different channel (i.e., it's a subdoc),
-        // ensure the parent is loaded and hold a reference to prevent GC.
+        // load the parent and pin it with an explicit Subdoc attachment:
+        // the guard both counts on the parent's actor and holds a parent
+        // awareness ref (which the strong-count probes still key on).
         // Lock order is strictly child slot → parent slot, and parents
         // never route elsewhere, so no cycle exists.
-        let parent_awareness_guard = if routing_channel_name != doc_id {
-            let parent = self.get_or_create_boxed(&routing_channel_name).await?;
-            Some(parent.awareness())
+        let parent_guard = if routing_channel_name != doc_id {
+            Some(
+                self.attach_doc_boxed(&routing_channel_name, AttachKind::Subdoc)
+                    .await?,
+            )
         } else {
             None
         };
@@ -461,13 +460,14 @@ impl Server {
             let user_for_callback = user.clone();
             let registry = self.registry.clone();
             let doc_id_for_callback = doc_id.to_string();
-            // Capture parent awareness to keep it alive (prevents GC while subdoc exists)
-            let _parent_awareness = parent_awareness_guard;
+            // The parent pin lives in this closure, which the doc owns via
+            // its SyncKv observer: the guard detaches when the doc drops.
+            let _parent_guard = parent_guard;
 
             if let Some(dispatcher) = event_dispatcher {
                 Some(Arc::new(move |mut event: DocumentUpdatedEvent| {
-                    // Keep parent awareness alive by referencing it in the closure
-                    let _ = &_parent_awareness;
+                    // Keep the parent pin alive by referencing it in the closure
+                    let _ = &_parent_guard;
                     // Add user to event if available
                     if let Some(ref user) = user_for_callback {
                         event.user = Some(user.clone());
@@ -556,6 +556,7 @@ impl Server {
                         doc_id.clone(),
                         checkpoint_freq,
                         cancellation_token,
+                        self.metrics.clone(),
                     )
                     .instrument(span!(Level::INFO, "gc_loop", doc_id=?doc_id)),
                 );
@@ -570,14 +571,35 @@ impl Server {
         doc_id: String,
         checkpoint_freq: Duration,
         cancellation_token: CancellationToken,
+        metrics: Arc<RelayMetrics>,
     ) {
         let mut checkpoints_without_refs = 0;
+        let mut consecutive_shadow_mismatches = 0u32;
 
         loop {
             tokio::select! {
                 _ = tokio::time::sleep(checkpoint_freq) => {
-                    if let Some(doc) = registry.peek(&doc_id) {
-                        let awareness = Arc::downgrade(&doc.awareness());
+                    if let Some(resident) = registry.peek_resident(&doc_id) {
+                        // Shadow-accounting soak: the explicit counts must
+                        // agree with the strong-count probe before eviction
+                        // can flip to them. A single-tick disagreement can
+                        // be an attach/detach caught mid-flight, so only
+                        // two consecutive mismatched ticks count as drift.
+                        if crate::doc_lifecycle::shadow_accounting_disagrees(&resident) {
+                            consecutive_shadow_mismatches += 1;
+                            if consecutive_shadow_mismatches >= 2 {
+                                metrics.record_lifecycle_accounting_mismatch();
+                                tracing::warn!(
+                                    doc_id = %doc_id,
+                                    connections = resident.handle.connections(),
+                                    "lifecycle shadow accounting mismatch: explicit counts disagree with the awareness strong-count probe"
+                                );
+                            }
+                        } else {
+                            consecutive_shadow_mismatches = 0;
+                        }
+
+                        let awareness = Arc::downgrade(&resident.doc.awareness());
                         if awareness.strong_count() > 1 {
                             checkpoints_without_refs = 0;
                             tracing::debug!("doc is still alive - it has {} references", awareness.strong_count());
@@ -741,17 +763,41 @@ impl Server {
             .await
     }
 
-    /// Boxed form of [`Self::get_or_create_doc`] for use inside
-    /// `build_doc`, which recursively calls it to load a subdoc's parent.
-    /// The recursion terminates because a parent never routes to another
-    /// channel, and no lock cycle exists because parent loads take only
-    /// the parent's own slot lock.
-    fn get_or_create_boxed<'a>(
+    /// Load (if needed) and attach to a doc. The guard is the unit of
+    /// explicit connection accounting; every socket, HTTP one-shot, and
+    /// subdoc parent pin holds one for exactly as long as it can touch
+    /// the doc.
+    pub async fn attach_doc(
+        &self,
+        doc_id: &str,
+        kind: AttachKind,
+        routing_channel: Option<String>,
+        user: Option<String>,
+    ) -> Result<AttachGuard> {
+        Self::validate_doc_id(doc_id)?;
+        self.registry
+            .attach(doc_id, kind, || {
+                let routing_channel = routing_channel.clone();
+                let user = user.clone();
+                async move {
+                    tracing::info!(doc_id=?doc_id, channel=?routing_channel, user=?user, "Loading doc");
+                    self.build_doc(doc_id, routing_channel, user).await
+                }
+            })
+            .await
+    }
+
+    /// Boxed form of [`Self::attach_doc`] for use inside `build_doc`,
+    /// which recursively calls it to pin a subdoc's parent. The recursion
+    /// terminates because a parent never routes to another channel, and
+    /// no lock cycle exists because parent loads take only the parent's
+    /// own slot lock.
+    fn attach_doc_boxed<'a>(
         &'a self,
         doc_id: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Arc<DocWithSyncKv>>> + Send + 'a>>
-    {
-        Box::pin(self.get_or_create_doc_with_channel_and_user(doc_id, None, None))
+        kind: AttachKind,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<AttachGuard>> + Send + 'a>> {
+        Box::pin(self.attach_doc(doc_id, kind, None, None))
     }
 
     pub fn check_auth(
@@ -963,12 +1009,12 @@ async fn get_doc_as_update(
     let token = get_token_from_header(auth_header);
     let _ = server_state.verify_doc_token(token.as_deref(), &doc_id)?;
 
-    let dwskv = server_state
-        .get_or_create_doc(&doc_id)
+    let guard = server_state
+        .attach_doc(&doc_id, AttachKind::Http, None, None)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
-    let update = dwskv.as_update();
+    let update = guard.doc().as_update();
     tracing::debug!("update: {:?}", update);
     Ok(update.into_response())
 }
@@ -1017,12 +1063,12 @@ async fn update_doc_inner(
         ));
     }
 
-    let dwskv = server_state
-        .get_or_create_doc(&doc_id)
+    let guard = server_state
+        .attach_doc(&doc_id, AttachKind::Http, None, None)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
-    if let Err(err) = dwskv.apply_update(&body) {
+    if let Err(err) = guard.doc().apply_update(&body) {
         tracing::error!(?err, "Failed to apply update");
         return Err(AppError::new(StatusCode::INTERNAL_SERVER_ERROR, err));
     }
@@ -1059,12 +1105,10 @@ async fn handle_socket_upgrade_with_channel_and_user(
     };
 
     let user_for_pud = user.clone();
-    let dwskv = server_state
-        .get_or_create_doc_with_channel_and_user(&doc_id, routing_channel, user)
+    let guard = server_state
+        .attach_doc(&doc_id, AttachKind::Socket, routing_channel, user)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
-    let awareness = dwskv.awareness();
-    let sync_kv = dwskv.sync_kv();
     // Socket loops watch the doc-close token (a child of the server token)
     // so shutdown can close them ahead of the graceful drain.
     let cancellation_token = server_state.doc_close_token.clone();
@@ -1072,11 +1116,12 @@ async fn handle_socket_upgrade_with_channel_and_user(
     let metrics = server_state.metrics.clone();
     let doc_id_clone = doc_id.clone();
 
+    // The guard moves into the upgrade closure: an abandoned upgrade
+    // detaches via RAII.
     Ok(ws.on_upgrade(move |socket| {
         handle_socket(
             socket,
-            awareness,
-            sync_kv,
+            guard,
             authorization,
             expiration_time,
             user_for_pud,
@@ -1203,8 +1248,7 @@ async fn handle_socket_upgrade_full_path(
 
 async fn handle_socket(
     socket: WebSocket,
-    awareness: Arc<RwLock<Awareness>>,
-    sync_kv: Arc<SyncKv>,
+    guard: AttachGuard,
     authorization: Authorization,
     expiration_time: Option<u64>,
     user: Option<String>,
@@ -1217,8 +1261,7 @@ async fn handle_socket(
     handle_socket_inner(
         sink,
         stream,
-        awareness,
-        sync_kv,
+        guard,
         authorization,
         expiration_time,
         user,
@@ -1236,8 +1279,7 @@ async fn handle_socket(
 async fn handle_socket_inner<S, T, E>(
     mut sink: S,
     mut stream: T,
-    awareness: Arc<RwLock<Awareness>>,
-    sync_kv: Arc<SyncKv>,
+    guard: AttachGuard,
     authorization: Authorization,
     expiration_time: Option<u64>,
     user: Option<String>,
@@ -1250,6 +1292,8 @@ async fn handle_socket_inner<S, T, E>(
     T: Stream<Item = Result<Message, E>> + Unpin,
     E: std::fmt::Debug,
 {
+    let awareness = guard.awareness();
+    let sync_kv = guard.sync_kv();
     let (send, mut recv) = channel(1024);
 
     // Cancelled when the writer task exits (sink write failure) or when the
@@ -1412,9 +1456,12 @@ async fn handle_socket_inner<S, T, E>(
     // socket drains, but the checkpoint throttle may still be holding
     // changes — an unsignaled suspend would freeze them dirty. Flush now:
     // it is the same PUT the throttle already owed, just earlier, and a
-    // no-op when clean. Holders of the awareness Arc at this point are the
-    // doc's DocWithSyncKv, this probe, and two per live connection.
+    // no-op when clean. The guard (and its awareness ref) must drop before
+    // the probe: holders at this point are then the doc's DocWithSyncKv,
+    // this probe, and three per other live connection (DocConnection,
+    // guard, probe).
     drop(connection);
+    drop(guard);
     if Arc::strong_count(&awareness_probe) <= 2 {
         if sync_kv_flush.is_dirty() {
             metrics.record_doc_dirty_at_drain();
@@ -2571,8 +2618,10 @@ async fn metrics_endpoint(State(_server_state): State<Arc<Server>>) -> Result<St
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::sync::RwLock;
     use y_sweet_core::api_types::Authorization;
     use y_sweet_core::auth::ExpirationTimeEpochMillis;
+    use y_sweet_core::sync::awareness::Awareness;
 
     #[tokio::test]
     async fn test_auth_doc() {
@@ -3297,6 +3346,57 @@ mod test {
             );
         }
 
+        /// The subdoc→parent pin contract: a parent must stay resident
+        /// while any of its subdocs is resident, and must become evictable
+        /// once the last subdoc is gone (the pin must not leak).
+        #[tokio::test(start_paused = true)]
+        async fn subdoc_parent_pinned_by_guard_not_closure() {
+            let store = MemoryStore::new();
+            let server = test_server(
+                Some(Box::new(store.clone())),
+                Duration::from_millis(10),
+                true,
+                CancellationToken::new(),
+            )
+            .await;
+
+            let parent_id = "parent-doc";
+            let child_id = "child-doc";
+            // Loading a doc with a routing channel != its own id makes it a
+            // subdoc; the load force-loads the parent and pins it.
+            server
+                .get_or_create_doc_with_channel(child_id, Some(parent_id.to_string()))
+                .await
+                .unwrap();
+            assert!(server.registry.is_resident(child_id));
+            assert!(server.registry.is_resident(parent_id));
+
+            // While the child is resident the parent must be pinned.
+            let mut ticks = 0;
+            while server.registry.is_resident(child_id) {
+                assert!(
+                    server.registry.is_resident(parent_id),
+                    "parent must not be evicted under a live subdoc"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                ticks += 1;
+                assert!(ticks < 100, "child was never GC-evicted");
+            }
+
+            // Once the child is gone its pin is released; the parent must
+            // itself be evictable (the pin must not leak).
+            for _ in 0..100 {
+                if !server.registry.is_resident(parent_id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            assert!(
+                !server.registry.is_resident(parent_id),
+                "parent pin leaked after the last subdoc was evicted"
+            );
+        }
+
         #[tokio::test(start_paused = true)]
         async fn http_update_persisted_within_checkpoint_freq() {
             let checkpoint_freq = Duration::from_secs(10);
@@ -3430,10 +3530,21 @@ mod test {
         struct SocketHarness {
             to_server: tokio::sync::mpsc::Sender<Result<Message, axum::Error>>,
             from_server: futures_mpsc::UnboundedReceiver<Message>,
-            awareness: Arc<RwLock<Awareness>>,
+            /// Keeps the doc alive, standing in for the registry slot. The
+            /// harness must NOT retain a raw awareness clone: the
+            /// last-disconnect probe counts awareness refs, and an extra
+            /// retained clone would shift its threshold.
+            doc: Arc<DocWithSyncKv>,
             sync_kv: Arc<SyncKv>,
             metrics: Arc<RelayMetrics>,
             task: tokio::task::JoinHandle<()>,
+        }
+
+        impl SocketHarness {
+            /// Transient awareness access for assertions.
+            fn awareness(&self) -> Arc<RwLock<Awareness>> {
+                self.doc.awareness()
+            }
         }
 
         /// Run handle_socket_inner against in-memory socket halves so
@@ -3442,15 +3553,20 @@ mod test {
             let (to_server, stream_rx) =
                 tokio::sync::mpsc::channel::<Result<Message, axum::Error>>(64);
             let (sink_tx, from_server) = futures_mpsc::unbounded::<Message>();
-            let awareness = Arc::new(RwLock::new(Awareness::new(yrs::Doc::new())));
             let metrics = RelayMetrics::new_with_registry(&prometheus::Registry::new()).unwrap();
-            let sync_kv = Arc::new(SyncKv::new(None, "test_doc", || ()).await.unwrap());
+            let doc = Arc::new(
+                DocWithSyncKv::new("test_doc", None, || (), None)
+                    .await
+                    .unwrap(),
+            );
+            let sync_kv = doc.sync_kv();
+            let handle = crate::doc_lifecycle::test_actor_handle("test_doc", metrics.clone());
+            let guard = handle.attach(crate::doc_lifecycle::AttachKind::Socket, &doc);
 
             let task = tokio::spawn(handle_socket_inner(
                 sink_tx,
                 ReceiverStream::new(stream_rx),
-                awareness.clone(),
-                sync_kv.clone(),
+                guard,
                 Authorization::Full,
                 None,
                 None,
@@ -3463,7 +3579,7 @@ mod test {
             SocketHarness {
                 to_server,
                 from_server,
-                awareness,
+                doc,
                 sync_kv,
                 metrics,
                 task,
@@ -3489,7 +3605,7 @@ mod test {
         #[tokio::test(start_paused = true)]
         async fn stream_eof_tears_down_connection_and_clears_awareness() {
             let harness = spawn_socket(CancellationToken::new()).await;
-            let base_clients = harness.awareness.read().unwrap().clients().len();
+            let base_clients = harness.awareness().read().unwrap().clients().len();
 
             harness
                 .to_server
@@ -3499,7 +3615,7 @@ mod test {
 
             tokio::time::timeout(Duration::from_secs(5), async {
                 loop {
-                    if harness.awareness.read().unwrap().clients().len() == base_clients + 1 {
+                    if harness.awareness().read().unwrap().clients().len() == base_clients + 1 {
                         break;
                     }
                     tokio::time::sleep(Duration::from_millis(10)).await;
@@ -3510,6 +3626,7 @@ mod test {
 
             // End the stream without a close handshake, as a vanished client
             // whose TCP connection got reset would.
+            let doc = harness.doc.clone();
             drop(harness.to_server);
 
             tokio::time::timeout(Duration::from_secs(5), harness.task)
@@ -3518,7 +3635,7 @@ mod test {
                 .unwrap();
 
             assert_eq!(
-                harness.awareness.read().unwrap().clients().len(),
+                doc.awareness().read().unwrap().clients().len(),
                 base_clients,
                 "DocConnection drop should remove the client's awareness state"
             );

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -1,3 +1,4 @@
+use crate::doc_lifecycle::{DocRegistry, EvictDecision, EvictOutcome};
 use anyhow::{anyhow, Result};
 use axum::{
     body::Bytes,
@@ -17,7 +18,6 @@ use axum::{
     Json, Router,
 };
 use axum_extra::typed_header::TypedHeader;
-use dashmap::{mapref::one::MappedRef, DashMap};
 use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -30,10 +30,7 @@ use std::{
 use tempfile::NamedTempFile;
 use tokio::{
     net::TcpListener,
-    sync::{
-        mpsc::{channel, error::TrySendError, Receiver},
-        Mutex as AsyncMutex,
-    },
+    sync::mpsc::{channel, error::TrySendError, Receiver},
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{span, Instrument, Level};
@@ -229,11 +226,9 @@ struct FileDownloadParams {
 }
 
 pub struct Server {
-    docs: Arc<DashMap<String, DocWithSyncKv>>,
-    /// Per-doc-id async locks held only across the load-from-store step
-    /// so concurrent first-time requests for the same doc don't both load
-    /// from the store and clobber each other in `docs`.
-    loading_locks: Arc<DashMap<String, Arc<AsyncMutex<()>>>>,
+    /// Owner of document identity: single-flight loads, eviction under
+    /// the slot lock, slots reclaimed at eviction and on failed loads.
+    registry: Arc<DocRegistry>,
     doc_worker_tracker: TaskTracker,
     store: Option<Arc<Box<dyn Store>>>,
     checkpoint_freq: Duration,
@@ -302,8 +297,7 @@ impl Server {
         tracing::info!("Event dispatcher created successfully");
 
         Ok(Self {
-            docs: Arc::new(DashMap::new()),
-            loading_locks: Arc::new(DashMap::new()),
+            registry: Arc::new(DocRegistry::new()),
             doc_worker_tracker: TaskTracker::new(),
             store: store.map(Arc::new),
             checkpoint_freq,
@@ -330,29 +324,29 @@ impl Server {
     }
 
     /// First beat of the client-compatible shutdown drain: persist every
-    /// resident doc while sockets stay open and serving. Deployed clients
-    /// stop retrying a dropped socket after a sub-second burst of refused
-    /// attempts, so the slow store work must happen before any
-    /// client-visible disconnect, keeping the close-to-exit window inside
-    /// that budget.
+    /// dirty doc while sockets stay open and serving, so the post-cutover
+    /// delta flush — and with it the close-to-exit window deployed
+    /// clients' sub-second retry budgets must survive — stays within a
+    /// handful of store round-trips. Races with the per-doc persistence
+    /// workers are the status-quo multi-writer behavior; the actor
+    /// migration serializes per-doc writes later.
     pub async fn flush_all_docs(&self) {
+        let docs = self.registry.resident_docs();
         let started = std::time::Instant::now();
-        // Collect handles first: a DashMap shard guard must not be held
-        // across an await.
-        let sync_kvs: Vec<_> = self
-            .docs
-            .iter()
-            .map(|entry| entry.value().sync_kv())
-            .collect();
-        let docs = sync_kvs.len();
-        for sync_kv in sync_kvs {
-            if let Err(e) = sync_kv.persist().await {
-                tracing::error!(?e, "Error persisting during pre-close flush");
+        let mut flushed = 0usize;
+        for doc in docs {
+            let sync_kv = doc.sync_kv();
+            if !sync_kv.is_dirty() {
+                continue;
+            }
+            match sync_kv.persist().await {
+                Ok(()) => flushed += 1,
+                Err(e) => tracing::error!(?e, "Error persisting during pre-close flush"),
             }
         }
         tracing::info!(
-            "pre-close flush: {} docs persisted in {} ms",
-            docs,
+            "pre-close flush: {} dirty docs persisted in {} ms",
+            flushed,
             started.elapsed().as_millis()
         );
     }
@@ -361,7 +355,7 @@ impl Server {
     /// run one final unthrottled persist when the server token cancels,
     /// so returning means the flush is fully on the store.
     pub async fn drain_doc_workers(&self) {
-        let docs = self.docs.len();
+        let docs = self.registry.len();
         let started = std::time::Instant::now();
         self.doc_worker_tracker.close();
         self.doc_worker_tracker.wait().await;
@@ -377,7 +371,7 @@ impl Server {
         if Self::validate_doc_id(doc_id).is_err() {
             return false;
         }
-        if self.docs.contains_key(doc_id) {
+        if self.registry.is_resident(doc_id) {
             return true;
         }
         if let Some(store) = &self.store {
@@ -416,12 +410,10 @@ impl Server {
         Ok(())
     }
 
-    pub fn load_doc<'a>(
-        &'a self,
-        doc_id: &'a str,
-        routing_channel: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
-        Box::pin(self.load_doc_with_user(doc_id, routing_channel, None))
+    pub async fn load_doc(&self, doc_id: &str, routing_channel: Option<String>) -> Result<()> {
+        self.get_or_create_doc_with_channel_and_user(doc_id, routing_channel, None)
+            .await?;
+        Ok(())
     }
 
     pub async fn load_doc_with_user(
@@ -430,7 +422,20 @@ impl Server {
         routing_channel: Option<String>,
         user: Option<String>,
     ) -> Result<()> {
-        Self::validate_doc_id(doc_id)?;
+        self.get_or_create_doc_with_channel_and_user(doc_id, routing_channel, user)
+            .await?;
+        Ok(())
+    }
+
+    /// Construct a doc instance and spawn its workers. Runs under the
+    /// registry's slot lock (as a `get_or_load` loader); the registry
+    /// installs the result.
+    async fn build_doc(
+        &self,
+        doc_id: &str,
+        routing_channel: Option<String>,
+        user: Option<String>,
+    ) -> Result<DocWithSyncKv> {
         let (send, recv) = channel(1024);
 
         // Determine routing channel: use provided channel or fallback to doc_id
@@ -440,15 +445,11 @@ impl Server {
 
         // If this doc routes to a different channel (i.e., it's a subdoc),
         // ensure the parent is loaded and hold a reference to prevent GC.
-        // The load goes through the per-key lock: concurrent subdoc loads
-        // (e.g. a folder's documents reconnecting together) otherwise race
-        // to load the same parent, and the losing insert orphans the
-        // winner's in-memory state and spawns duplicate persistence workers.
+        // Lock order is strictly child slot → parent slot, and parents
+        // never route elsewhere, so no cycle exists.
         let parent_awareness_guard = if routing_channel_name != doc_id {
-            self.ensure_doc_loaded_boxed(&routing_channel_name).await?;
-            self.docs
-                .get(&routing_channel_name)
-                .map(|parent| parent.awareness())
+            let parent = self.get_or_create_boxed(&routing_channel_name).await?;
+            Some(parent.awareness())
         } else {
             None
         };
@@ -458,7 +459,7 @@ impl Server {
             let event_dispatcher = self.event_dispatcher.clone();
             let routing_channel_for_callback = routing_channel_name.clone();
             let user_for_callback = user.clone();
-            let docs = self.docs.clone();
+            let registry = self.registry.clone();
             let doc_id_for_callback = doc_id.to_string();
             // Capture parent awareness to keep it alive (prevents GC while subdoc exists)
             let _parent_awareness = parent_awareness_guard;
@@ -475,7 +476,7 @@ impl Server {
                     // Update parent's subdoc snapshot index
                     if routing_channel_for_callback != doc_id_for_callback {
                         if let Some(snapshot) = &event.snapshot {
-                            if let Some(parent) = docs.get(&routing_channel_for_callback) {
+                            if let Some(parent) = registry.peek(&routing_channel_for_callback) {
                                 parent
                                     .update_subdoc_snapshot(&doc_id_for_callback, snapshot.clone());
                             }
@@ -551,8 +552,7 @@ impl Server {
             if self.doc_gc {
                 self.doc_worker_tracker.spawn(
                     Self::doc_gc_worker(
-                        self.docs.clone(),
-                        self.loading_locks.clone(),
+                        self.registry.clone(),
                         doc_id.clone(),
                         checkpoint_freq,
                         cancellation_token,
@@ -562,13 +562,11 @@ impl Server {
             }
         }
 
-        self.docs.insert(doc_id.to_string(), dwskv);
-        Ok(())
+        Ok(dwskv)
     }
 
     async fn doc_gc_worker(
-        docs: Arc<DashMap<String, DocWithSyncKv>>,
-        loading_locks: Arc<DashMap<String, Arc<AsyncMutex<()>>>>,
+        registry: Arc<DocRegistry>,
         doc_id: String,
         checkpoint_freq: Duration,
         cancellation_token: CancellationToken,
@@ -578,7 +576,7 @@ impl Server {
         loop {
             tokio::select! {
                 _ = tokio::time::sleep(checkpoint_freq) => {
-                    if let Some(doc) = docs.get(&doc_id) {
+                    if let Some(doc) = registry.peek(&doc_id) {
                         let awareness = Arc::downgrade(&doc.awareness());
                         if awareness.strong_count() > 1 {
                             checkpoints_without_refs = 0;
@@ -592,57 +590,54 @@ impl Server {
                     }
 
                     if checkpoints_without_refs >= 2 {
-                        // Eviction is atomic with respect to attachment: it
-                        // holds the same per-doc lock ensure_doc_loaded takes,
-                        // so a loader either finds the doc in the map or
-                        // waits until the store already holds the final
-                        // flush.
-                        let lock = {
-                            let entry = loading_locks
-                                .entry(doc_id.clone())
-                                .or_insert_with(|| Arc::new(AsyncMutex::new(())));
-                            Arc::clone(entry.value())
-                        };
-                        let _guard = lock.lock().await;
+                        // Eviction runs under the registry's slot lock: a
+                        // loader either finds the doc resident or waits
+                        // until the store already holds the final flush.
+                        let outcome = registry.evict(&doc_id, |doc| async move {
+                            // A connection may have attached between the
+                            // idle checks and taking the slot lock; it
+                            // holds awareness refs. Un-evict rather than
+                            // orphan it on an instance the registry no
+                            // longer knows: an orphan's updates dispatch
+                            // only to its own instance and are invisible
+                            // to every later connection.
+                            let probe = Arc::downgrade(&doc.awareness());
+                            if probe.strong_count() > 1 {
+                                tracing::info!("attach raced GC; un-evicting doc");
+                                return EvictDecision::Refuse;
+                            }
+                            tracing::info!("GCing doc");
+                            // Compact PUD before shutdown: dedup ids, clear
+                            // ds. The mutations create tombstones which yrs
+                            // GC will clean up, and the update observer
+                            // marks SyncKv dirty so the compacted state
+                            // gets persisted.
+                            let result = doc.compact_user_data();
+                            if !result.is_empty() {
+                                tracing::debug!(
+                                    ids_removed = result.ids_removed,
+                                    ds_removed = result.ds_removed,
+                                    "Compacted PermanentUserData"
+                                );
+                            }
+                            // The final state must reach the store before
+                            // the slot lock releases: a reload racing a
+                            // fire-and-forget flush loads a stale snapshot
+                            // and its next persist rolls the doc back.
+                            if let Err(e) = doc.sync_kv().persist().await {
+                                tracing::error!(?e, "Error persisting during GC eviction");
+                            }
+                            doc.sync_kv().shutdown();
+                            EvictDecision::Evict
+                        }).await;
 
-                        let Some((_, doc)) = docs.remove(&doc_id) else {
-                            break;
-                        };
-                        // A connection may have attached between the idle
-                        // checks and taking the lock; it holds awareness
-                        // refs. Un-evict rather than orphan it on an
-                        // instance the map no longer knows: an orphan's
-                        // updates dispatch only to its own instance and are
-                        // invisible to every later connection.
-                        let probe = Arc::downgrade(&doc.awareness());
-                        if probe.strong_count() > 1 {
-                            tracing::info!("attach raced GC; un-evicting doc");
-                            docs.insert(doc_id.clone(), doc);
-                            checkpoints_without_refs = 0;
-                            continue;
+                        match outcome {
+                            EvictOutcome::Refused => {
+                                checkpoints_without_refs = 0;
+                                continue;
+                            }
+                            EvictOutcome::Evicted | EvictOutcome::Absent => break,
                         }
-                        tracing::info!("GCing doc");
-                        // Compact PUD before shutdown: dedup ids, clear ds.
-                        // The mutations create tombstones which yrs GC will
-                        // clean up, and the update observer marks SyncKv
-                        // dirty so the compacted state gets persisted.
-                        let result = doc.compact_user_data();
-                        if !result.is_empty() {
-                            tracing::debug!(
-                                ids_removed = result.ids_removed,
-                                ds_removed = result.ds_removed,
-                                "Compacted PermanentUserData"
-                            );
-                        }
-                        // The final state must reach the store before the
-                        // loading lock releases: a reload racing a
-                        // fire-and-forget flush loads a stale snapshot and
-                        // its next persist rolls the doc back.
-                        if let Err(e) = doc.sync_kv().persist().await {
-                            tracing::error!(?e, "Error persisting during GC eviction");
-                        }
-                        doc.sync_kv().shutdown();
-                        break;
                     }
                 }
                 _ = cancellation_token.cancelled() => {
@@ -713,24 +708,16 @@ impl Server {
         tracing::info!("Terminating loop for {}", doc_id);
     }
 
-    pub async fn get_or_create_doc(
-        &self,
-        doc_id: &str,
-    ) -> Result<MappedRef<'_, String, DocWithSyncKv, DocWithSyncKv>> {
-        self.ensure_doc_loaded(doc_id, None, None).await?;
-
-        Ok(self
-            .docs
-            .get(doc_id)
-            .ok_or_else(|| anyhow!("Failed to get-or-create doc"))?
-            .map(|d| d))
+    pub async fn get_or_create_doc(&self, doc_id: &str) -> Result<Arc<DocWithSyncKv>> {
+        self.get_or_create_doc_with_channel_and_user(doc_id, None, None)
+            .await
     }
 
     pub async fn get_or_create_doc_with_channel(
         &self,
         doc_id: &str,
         routing_channel: Option<String>,
-    ) -> Result<MappedRef<'_, String, DocWithSyncKv, DocWithSyncKv>> {
+    ) -> Result<Arc<DocWithSyncKv>> {
         self.get_or_create_doc_with_channel_and_user(doc_id, routing_channel, None)
             .await
     }
@@ -740,64 +727,31 @@ impl Server {
         doc_id: &str,
         routing_channel: Option<String>,
         user: Option<String>,
-    ) -> Result<MappedRef<'_, String, DocWithSyncKv, DocWithSyncKv>> {
-        self.ensure_doc_loaded(doc_id, routing_channel, user)
-            .await?;
-
-        Ok(self
-            .docs
-            .get(doc_id)
-            .ok_or_else(|| anyhow!("Failed to get-or-create doc"))?
-            .map(|d| d))
+    ) -> Result<Arc<DocWithSyncKv>> {
+        Self::validate_doc_id(doc_id)?;
+        self.registry
+            .get_or_load(doc_id, || {
+                let routing_channel = routing_channel.clone();
+                let user = user.clone();
+                async move {
+                    tracing::info!(doc_id=?doc_id, channel=?routing_channel, user=?user, "Loading doc");
+                    self.build_doc(doc_id, routing_channel, user).await
+                }
+            })
+            .await
     }
 
-    /// Idempotently load `doc_id` into `self.docs`. Concurrent callers for
-    /// the same doc_id serialize through a per-key async mutex so that only
-    /// one `load_doc` actually hits the store; the others observe the
-    /// already-loaded entry on a double-check after the lock is acquired.
-    async fn ensure_doc_loaded(
-        &self,
-        doc_id: &str,
-        routing_channel: Option<String>,
-        user: Option<String>,
-    ) -> Result<()> {
-        if self.docs.contains_key(doc_id) {
-            return Ok(());
-        }
-
-        // Acquire (or create) the per-key lock without holding the DashMap
-        // shard guard across the `.lock().await` below.
-        let lock = {
-            let entry = self
-                .loading_locks
-                .entry(doc_id.to_string())
-                .or_insert_with(|| Arc::new(AsyncMutex::new(())));
-            Arc::clone(entry.value())
-        };
-        let _guard = lock.lock().await;
-
-        // Double-check after acquiring the lock: another caller may have
-        // loaded while we were waiting.
-        if self.docs.contains_key(doc_id) {
-            return Ok(());
-        }
-
-        tracing::info!(doc_id=?doc_id, channel=?routing_channel, user=?user, "Loading doc");
-        self.load_doc_with_user(doc_id, routing_channel, user)
-            .await?;
-        Ok(())
-    }
-
-    /// Boxed form of [`Self::ensure_doc_loaded`] for use inside
-    /// `load_doc_with_user`, which it recursively calls to load a subdoc's
-    /// parent. The recursion terminates because a parent never routes to
-    /// another channel, and no lock cycle exists because parent loads take
-    /// only the parent's own key lock.
-    fn ensure_doc_loaded_boxed<'a>(
+    /// Boxed form of [`Self::get_or_create_doc`] for use inside
+    /// `build_doc`, which recursively calls it to load a subdoc's parent.
+    /// The recursion terminates because a parent never routes to another
+    /// channel, and no lock cycle exists because parent loads take only
+    /// the parent's own slot lock.
+    fn get_or_create_boxed<'a>(
         &'a self,
         doc_id: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
-        Box::pin(self.ensure_doc_loaded(doc_id, None, None))
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Arc<DocWithSyncKv>>> + Send + 'a>>
+    {
+        Box::pin(self.get_or_create_doc_with_channel_and_user(doc_id, None, None))
     }
 
     pub fn check_auth(
@@ -2791,7 +2745,7 @@ mod test {
         )
         .await;
 
-        assert!(!server.docs.contains_key(doc_id));
+        assert!(!server.registry.is_resident(doc_id));
         server
             .ensure_socket_doc_access(doc_id, Authorization::ReadOnly)
             .await
@@ -3247,7 +3201,7 @@ mod test {
         let doc_id = server.create_doc().await.unwrap();
 
         // Verify the doc exists
-        assert!(server.docs.contains_key(&doc_id));
+        assert!(server.registry.is_resident(&doc_id));
 
         // The doc has no external references (we're not holding an awareness Arc),
         // so it should be eligible for GC after 2 checkpoint intervals.
@@ -3256,7 +3210,7 @@ mod test {
 
         // Doc should be removed by GC
         assert!(
-            !server.docs.contains_key(&doc_id),
+            !server.registry.is_resident(&doc_id),
             "Doc should have been garbage collected"
         );
 
@@ -3279,33 +3233,8 @@ mod test {
     /// every migration step.
     mod lifecycle_characterization {
         use super::*;
-        use crate::test_util::{test_server, GatedStore};
+        use crate::test_util::{content_update, read_content, test_server, GatedStore};
         use y_sweet_core::store::memory::MemoryStore;
-        use yrs::{Map, Out, ReadTxn, Transact};
-
-        /// A v1 update inserting `value` under `key` in the "data" map.
-        fn content_update(key: &str, value: &str) -> Vec<u8> {
-            let doc = yrs::Doc::new();
-            let map = doc.get_or_insert_map("data");
-            {
-                let mut txn = doc.transact_mut();
-                map.insert(&mut txn, key, value);
-            }
-            let txn = doc.transact();
-            txn.encode_state_as_update_v1(&yrs::StateVector::default())
-        }
-
-        fn read_content(dwskv: &DocWithSyncKv, key: &str) -> Option<String> {
-            let awareness = dwskv.awareness();
-            let awareness = awareness.read().unwrap();
-            let doc = awareness.doc();
-            let txn = doc.transact();
-            let map = txn.get_map("data")?;
-            match map.get(&txn, key) {
-                Some(Out::Any(yrs::Any::String(s))) => Some(s.to_string()),
-                _ => None,
-            }
-        }
 
         #[tokio::test(start_paused = true)]
         async fn evicted_doc_state_survives_reload() {
@@ -3330,12 +3259,12 @@ mod test {
             // time auto-advances through the worker sleeps.
             for _ in 0..50 {
                 tokio::time::sleep(Duration::from_millis(10)).await;
-                if !server.docs.contains_key(&doc_id) {
+                if !server.registry.is_resident(&doc_id) {
                     break;
                 }
             }
             assert!(
-                !server.docs.contains_key(&doc_id),
+                !server.registry.is_resident(&doc_id),
                 "doc should have been GC-evicted"
             );
 
@@ -3363,7 +3292,7 @@ mod test {
             // Many multiples of the two-probe GC cadence.
             tokio::time::sleep(Duration::from_millis(200)).await;
             assert!(
-                server.docs.contains_key(&doc_id),
+                server.registry.is_resident(&doc_id),
                 "a held awareness ref is the current liveness contract; GC must not evict"
             );
         }
@@ -3405,6 +3334,50 @@ mod test {
             assert_ne!(baseline, Some(after));
             let dwskv = server.get_or_create_doc(&doc_id).await.unwrap();
             assert!(!dwskv.sync_kv().is_dirty());
+        }
+
+        /// Beat one of the client-compatible drain: the pre-close flush
+        /// persists every dirty doc while sockets stay open and docs stay
+        /// resident — it must not close, evict, or cancel anything.
+        #[tokio::test(start_paused = true)]
+        async fn shutdown_flush_persists_while_docs_keep_serving() {
+            let store = MemoryStore::new();
+            let server = Arc::new(
+                test_server(
+                    Some(Box::new(store.clone())),
+                    // Long checkpoint so the persistence worker can't be
+                    // the one doing the flushing.
+                    Duration::from_secs(600),
+                    false,
+                    CancellationToken::new(),
+                )
+                .await,
+            );
+
+            let doc_id = server.create_doc().await.unwrap();
+            {
+                let dwskv = server.get_or_create_doc(&doc_id).await.unwrap();
+                dwskv.apply_update(&content_update("k", "v")).unwrap();
+                assert!(dwskv.sync_kv().is_dirty());
+            }
+
+            server.flush_all_docs().await;
+
+            let key = format!("{doc_id}/data.ysweet");
+            assert!(
+                store.get_bytes(&key).is_some(),
+                "pre-close flush must reach the store"
+            );
+            let dwskv = server.get_or_create_doc(&doc_id).await.unwrap();
+            assert!(!dwskv.sync_kv().is_dirty());
+            assert!(
+                server.registry.is_resident(&doc_id),
+                "the flush must not evict"
+            );
+            assert!(
+                !server.doc_close_token.is_cancelled(),
+                "the flush must not close sockets"
+            );
         }
 
         #[tokio::test(start_paused = true)]

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -307,6 +307,49 @@ impl Server {
         })
     }
 
+    /// First beat of the client-compatible shutdown drain: persist every
+    /// resident doc while sockets stay open and serving. Deployed clients
+    /// stop retrying a dropped socket after a sub-second burst of refused
+    /// attempts, so the slow store work must happen before any
+    /// client-visible disconnect, keeping the close-to-exit window inside
+    /// that budget.
+    pub async fn flush_all_docs(&self) {
+        let started = std::time::Instant::now();
+        // Collect handles first: a DashMap shard guard must not be held
+        // across an await.
+        let sync_kvs: Vec<_> = self
+            .docs
+            .iter()
+            .map(|entry| entry.value().sync_kv())
+            .collect();
+        let docs = sync_kvs.len();
+        for sync_kv in sync_kvs {
+            if let Err(e) = sync_kv.persist().await {
+                tracing::error!(?e, "Error persisting during pre-close flush");
+            }
+        }
+        tracing::info!(
+            "pre-close flush: {} docs persisted in {} ms",
+            docs,
+            started.elapsed().as_millis()
+        );
+    }
+
+    /// Wait for every per-doc worker to finish. The persistence workers
+    /// run one final unthrottled persist when the server token cancels,
+    /// so returning means the flush is fully on the store.
+    pub async fn drain_doc_workers(&self) {
+        let docs = self.docs.len();
+        let started = std::time::Instant::now();
+        self.doc_worker_tracker.close();
+        self.doc_worker_tracker.wait().await;
+        tracing::info!(
+            "final flush: {} docs persisted in {} ms",
+            docs,
+            started.elapsed().as_millis()
+        );
+    }
+
     pub async fn doc_exists(&self, doc_id: &str) -> bool {
         // Reject system keys
         if Self::validate_doc_id(doc_id).is_err() {
@@ -838,11 +881,7 @@ impl Server {
             tracing::info!("Event dispatcher shutdown complete");
         }
 
-        tracing::info!("Closing doc worker tracker...");
-        self.doc_worker_tracker.close();
-        tracing::info!("Waiting for doc workers to finish...");
-        self.doc_worker_tracker.wait().await;
-        tracing::info!("All doc workers stopped");
+        self.drain_doc_workers().await;
 
         Ok(())
     }
@@ -2422,6 +2461,33 @@ mod test {
         assert_eq!(token.url, expected_url);
         assert_eq!(token.doc_id, doc_id);
         assert!(token.token.is_none());
+    }
+
+    #[tokio::test]
+    async fn drain_doc_workers_completes_after_cancel() {
+        let token = CancellationToken::new();
+        let server = Server::new(
+            None,
+            Duration::from_secs(60),
+            None,
+            None,
+            vec![],
+            token.clone(),
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // A live doc spawns persistence (and gc) workers; despite the 60s
+        // checkpoint throttle, cancellation must run the final persist and
+        // let the drain return promptly.
+        server.create_doc().await.unwrap();
+        token.cancel();
+
+        tokio::time::timeout(Duration::from_secs(5), server.drain_doc_workers())
+            .await
+            .expect("doc workers did not finish their final persist");
     }
 
     #[tokio::test]

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -510,7 +510,10 @@ impl Server {
             doc_id,
             self.store.clone(),
             move || {
-                send.try_send(()).unwrap();
+                // Best-effort wake: after eviction the persistence worker is
+                // gone and the channel is closed; the teardown-time persist()
+                // covers those writes instead of a panic here.
+                let _ = send.try_send(());
             },
             event_callback,
         )
@@ -1313,6 +1316,11 @@ async fn handle_socket_inner<S, T, E>(
 
     let send_clone = send.clone();
     let metrics_clone = metrics.clone();
+    // Held past the connection's lifetime: the awareness strong count tells
+    // the teardown whether this handler was the doc's last connection (the
+    // same liveness test the gc worker uses), and the flush needs the kv.
+    let awareness_probe = awareness.clone();
+    let sync_kv_flush = sync_kv.clone();
     let mut conn = DocConnection::new_with_expiration(
         awareness,
         authorization,
@@ -1445,6 +1453,22 @@ async fn handle_socket_inner<S, T, E>(
     };
 
     metrics.record_websocket_close(close_reason);
+
+    // The park window (auto-suspend / auto-stop) opens when a doc's last
+    // socket drains, but the checkpoint throttle may still be holding
+    // changes — an unsignaled suspend would freeze them dirty. Flush now:
+    // it is the same PUT the throttle already owed, just earlier, and a
+    // no-op when clean. Holders of the awareness Arc at this point are the
+    // doc's DocWithSyncKv, this probe, and two per live connection.
+    drop(connection);
+    if Arc::strong_count(&awareness_probe) <= 2 {
+        if sync_kv_flush.is_dirty() {
+            metrics.record_doc_dirty_at_drain();
+        }
+        if let Err(e) = sync_kv_flush.persist().await {
+            tracing::error!(?e, doc_id = %doc_id, "Error persisting on last disconnect");
+        }
+    }
 }
 
 async fn check_store(
@@ -3335,6 +3359,7 @@ mod test {
             to_server: tokio::sync::mpsc::Sender<Result<Message, axum::Error>>,
             from_server: futures_mpsc::UnboundedReceiver<Message>,
             awareness: Arc<RwLock<Awareness>>,
+            sync_kv: Arc<SyncKv>,
             metrics: Arc<RelayMetrics>,
             task: tokio::task::JoinHandle<()>,
         }
@@ -3353,7 +3378,7 @@ mod test {
                 sink_tx,
                 ReceiverStream::new(stream_rx),
                 awareness.clone(),
-                sync_kv,
+                sync_kv.clone(),
                 Authorization::Full,
                 None,
                 None,
@@ -3367,6 +3392,7 @@ mod test {
                 to_server,
                 from_server,
                 awareness,
+                sync_kv,
                 metrics,
                 task,
             }
@@ -3457,6 +3483,42 @@ mod test {
                 .unwrap();
 
             assert_eq!(closes(&harness.metrics, "server_shutdown"), 1.0);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn last_disconnect_flushes_dirty_doc() {
+            let harness = spawn_socket(CancellationToken::new()).await;
+
+            // Dirty the doc the way any metadata/content change would,
+            // inside the checkpoint throttle window.
+            let mut meta = std::collections::BTreeMap::new();
+            meta.insert(
+                "k".to_string(),
+                ciborium::value::Value::Text("v".to_string()),
+            );
+            harness.sync_kv.set_metadata(meta);
+            assert!(harness.sync_kv.is_dirty());
+
+            // Last (only) connection drops; the park window opens here.
+            drop(harness.to_server);
+
+            tokio::time::timeout(Duration::from_secs(5), harness.task)
+                .await
+                .expect("read loop kept running after stream EOF")
+                .unwrap();
+
+            assert!(
+                !harness.sync_kv.is_dirty(),
+                "last disconnect must flush before the park window opens"
+            );
+            assert_eq!(
+                harness
+                    .metrics
+                    .doc_dirty_at_drain_total
+                    .with_label_values(&[])
+                    .get(),
+                1.0
+            );
         }
 
         #[tokio::test(start_paused = true)]

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -60,6 +60,13 @@ use y_sweet_core::{
 
 const RELAY_SERVER_VERSION: &str = env!("GIT_VERSION");
 
+/// How often the server pings each WebSocket connection.
+const PING_EVERY: Duration = Duration::from_secs(20);
+/// How long a connection may go silent (no pong) before it is counted as a
+/// would-be keepalive reap. Observe-only: the connection is never closed for
+/// this; the metric exists to measure whether enforcement would be safe.
+const PONG_TIMEOUT: Duration = Duration::from_secs(40);
+
 #[derive(Clone, Debug)]
 pub struct AllowedHost {
     pub host: String,
@@ -1338,6 +1345,15 @@ async fn handle_socket_inner<S, T, E>(
     // Register the connection with the sync protocol event sender
     sync_protocol_event_sender.register_doc_connection(doc_id.clone(), Arc::downgrade(&connection));
 
+    // Observe-only keepalive: ping on an interval and record would-be reaps
+    // (silent past PONG_TIMEOUT) and recoveries (a pong after the timeout,
+    // i.e. a live connection enforcement would have killed). Nothing is
+    // closed on timeout until the soak metrics show enforcement is safe.
+    let mut ticker = tokio::time::interval(PING_EVERY);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut last_pong = tokio::time::Instant::now();
+    let mut pong_timed_out = false;
+
     let close_reason = loop {
         tokio::select! {
             msg = stream.next() => {
@@ -1348,6 +1364,23 @@ async fn handle_socket_inner<S, T, E>(
                 let msg = match msg {
                     Ok(Message::Binary(bytes)) => bytes,
                     Ok(Message::Close(_)) => break "close_frame",
+                    Ok(Message::Pong(_)) => {
+                        if pong_timed_out {
+                            pong_timed_out = false;
+                            metrics.record_pong_recovery();
+                            tracing::info!(
+                                doc_id = %doc_id,
+                                silent_secs = last_pong.elapsed().as_secs(),
+                                "Connection recovered after pong timeout; a keepalive reaper would have closed it"
+                            );
+                        }
+                        last_pong = tokio::time::Instant::now();
+                        continue;
+                    }
+                    Ok(Message::Ping(_)) => {
+                        // The transport replies with a pong automatically.
+                        continue;
+                    }
                     Err(_e) => {
                         // The stream will complain about things like
                         // connections being lost without handshake.
@@ -1382,6 +1415,17 @@ async fn handle_socket_inner<S, T, E>(
                         tracing::warn!(?e, "Error handling message");
                     }
                 }
+            }
+            _ = ticker.tick() => {
+                if last_pong.elapsed() > PONG_TIMEOUT && !pong_timed_out {
+                    pong_timed_out = true;
+                    metrics.record_pong_timeout();
+                    tracing::info!(
+                        doc_id = %doc_id,
+                        "Pong timeout (observe-only): a keepalive reaper would close this connection"
+                    );
+                }
+                let _ = send.try_send(Message::Ping(vec![]));
             }
             _ = conn_token.cancelled() => {
                 if cancellation_token.is_cancelled() {
@@ -3437,6 +3481,67 @@ mod test {
             }
             let frame = last_close.expect("no close frame reached the client");
             assert_eq!(frame.code, 1001);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn pong_timeout_is_observe_only() {
+            let mut harness = spawn_socket(CancellationToken::new()).await;
+
+            // Stay silent long past PONG_TIMEOUT: the would-be reap is
+            // recorded exactly once and the connection stays open.
+            tokio::time::sleep(Duration::from_secs(130)).await;
+            assert_eq!(
+                harness
+                    .metrics
+                    .websocket_pong_timeouts_total
+                    .with_label_values(&[])
+                    .get(),
+                1.0,
+                "one silent stretch should count as one would-be reap, not one per tick"
+            );
+            assert!(
+                !harness.task.is_finished(),
+                "observe-only keepalive must not close the connection"
+            );
+
+            // The server should still be probing.
+            let mut pings = 0;
+            while let Ok(Some(msg)) = harness.from_server.try_next() {
+                if matches!(msg, Message::Ping(_)) {
+                    pings += 1;
+                }
+            }
+            assert!(pings > 0, "server should send keepalive pings");
+
+            // A late pong is a live connection enforcement would have killed.
+            harness
+                .to_server
+                .send(Ok(Message::Pong(vec![])))
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            assert_eq!(
+                harness
+                    .metrics
+                    .websocket_pong_recoveries_total
+                    .with_label_values(&[])
+                    .get(),
+                1.0
+            );
+
+            // A second silent stretch counts as a new would-be reap.
+            tokio::time::sleep(Duration::from_secs(130)).await;
+            assert_eq!(
+                harness
+                    .metrics
+                    .websocket_pong_timeouts_total
+                    .with_label_values(&[])
+                    .get(),
+                2.0
+            );
+            assert!(!harness.task.is_finished());
+
+            harness.task.abort();
         }
     }
 }

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -579,7 +579,7 @@ impl Server {
             if !is_done && now - last_save < checkpoint_freq {
                 let sleep = tokio::time::sleep(checkpoint_freq - (now - last_save));
                 tokio::pin!(sleep);
-                tracing::info!("Throttling.");
+                tracing::debug!("Throttling.");
 
                 loop {
                     tokio::select! {
@@ -587,18 +587,18 @@ impl Server {
                             break;
                         }
                         v = recv.recv() => {
-                            tracing::info!("Received dirty while throttling.");
+                            tracing::debug!("Received dirty while throttling.");
                             if v.is_none() {
                                 break;
                             }
                         }
                         _ = cancellation_token.cancelled() => {
-                            tracing::info!("Received cancellation while throttling.");
+                            tracing::debug!("Received cancellation while throttling.");
                             break;
                         }
 
                     }
-                    tracing::info!("Done throttling.");
+                    tracing::debug!("Done throttling.");
                 }
             }
             tracing::debug!("Persisting.");
@@ -613,7 +613,7 @@ impl Server {
                 break;
             }
         }
-        tracing::info!("Terminating loop for {}", doc_id);
+        tracing::debug!("Terminating loop for {}", doc_id);
     }
 
     pub async fn get_or_create_doc(&self, doc_id: &str) -> Result<Arc<DocWithSyncKv>> {
@@ -1200,13 +1200,30 @@ async fn handle_socket_inner<S, T, E>(
 
     let send_clone = send.clone();
     let metrics_clone = metrics.clone();
+    let callback_doc_id = doc_id.clone();
+    let callback_user = user.clone();
+    // A wedged client can stay full for hours; per-message warns have produced
+    // millions of identical, contextless lines in one incident. Log the
+    // full/recovered transitions with identity, count drops in between.
+    let channel_full = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let dropped_while_full = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let mut conn = DocConnection::new_with_expiration(
         awareness,
         authorization,
         expiration_time,
         move |bytes| {
             match send_clone.try_send(Message::Binary(bytes.to_vec())) {
-                Ok(()) => {}
+                Ok(()) => {
+                    if channel_full.swap(false, std::sync::atomic::Ordering::Relaxed) {
+                        tracing::info!(
+                            doc_id = %callback_doc_id,
+                            user = ?callback_user,
+                            dropped = dropped_while_full
+                                .swap(0, std::sync::atomic::Ordering::Relaxed),
+                            "Outbound channel recovered; messages were dropped while full"
+                        );
+                    }
+                }
                 Err(TrySendError::Closed(_)) => {
                     // The writer task has exited; the read loop tears the
                     // connection down as soon as it sees the cancelled token,
@@ -1214,11 +1231,18 @@ async fn handle_socket_inner<S, T, E>(
                     metrics_clone.record_websocket_send_failure("closed");
                     tracing::debug!("Dropping outbound message: writer task exited");
                 }
-                Err(e @ TrySendError::Full(_)) => {
+                Err(TrySendError::Full(_)) => {
                     // A dropped update silently desyncs this client until it
                     // reconnects; the metric tracks how often that happens.
                     metrics_clone.record_websocket_send_failure("full");
-                    tracing::warn!(?e, "Outbound channel full; dropping message");
+                    dropped_while_full.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if !channel_full.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        tracing::warn!(
+                            doc_id = %callback_doc_id,
+                            user = ?callback_user,
+                            "Outbound channel full; dropping messages until it recovers"
+                        );
+                    }
                 }
             }
         },

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -2659,7 +2659,7 @@ mod test {
         assert!(token.token.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn drain_doc_workers_completes_after_cancel() {
         let token = CancellationToken::new();
         let server = Server::new(
@@ -2773,53 +2773,23 @@ mod test {
 
     #[tokio::test]
     async fn test_read_only_socket_access_allows_persisted_unloaded_doc() {
-        use async_trait::async_trait;
-        use std::collections::HashSet;
-        use y_sweet_core::store::Result as StoreResult;
-
-        struct ExistingDocStore {
-            existing_keys: HashSet<String>,
-        }
-
-        #[async_trait]
-        impl Store for ExistingDocStore {
-            async fn init(&self) -> StoreResult<()> {
-                Ok(())
-            }
-
-            async fn get(&self, _key: &str) -> StoreResult<Option<Vec<u8>>> {
-                Ok(None)
-            }
-
-            async fn set(&self, _key: &str, _value: Vec<u8>) -> StoreResult<()> {
-                Ok(())
-            }
-
-            async fn remove(&self, _key: &str) -> StoreResult<()> {
-                Ok(())
-            }
-
-            async fn exists(&self, key: &str) -> StoreResult<bool> {
-                Ok(self.existing_keys.contains(key))
-            }
-        }
+        use y_sweet_core::store::memory::MemoryStore;
 
         let doc_id = "persisted-doc";
-        let store = ExistingDocStore {
-            existing_keys: HashSet::from([format!("{}/data.ysweet", doc_id)]),
-        };
-        let server = Server::new(
+        let store = MemoryStore::new();
+        // Seed the store so the doc exists without being loaded. The
+        // access check only consults `exists`, never the bytes.
+        store
+            .set(&format!("{}/data.ysweet", doc_id), vec![])
+            .await
+            .unwrap();
+        let server = crate::test_util::test_server(
             Some(Box::new(store)),
             Duration::from_secs(60),
-            None,
-            None,
-            vec![],
-            CancellationToken::new(),
             true,
-            None,
+            CancellationToken::new(),
         )
-        .await
-        .unwrap();
+        .await;
 
         assert!(!server.docs.contains_key(doc_id));
         server
@@ -2841,52 +2811,7 @@ mod test {
 
     #[tokio::test]
     async fn test_file_head_endpoint() {
-        use async_trait::async_trait;
-        use std::collections::HashMap;
-        use std::sync::Arc;
-        use y_sweet_core::store::Result as StoreResult;
-
-        // Create a mock store for testing
-        #[derive(Clone)]
-        struct MockStore {
-            files: Arc<HashMap<String, Vec<u8>>>,
-        }
-
-        #[async_trait]
-        impl Store for MockStore {
-            async fn init(&self) -> StoreResult<()> {
-                Ok(())
-            }
-
-            async fn get(&self, key: &str) -> StoreResult<Option<Vec<u8>>> {
-                Ok(self.files.get(key).cloned())
-            }
-
-            async fn set(&self, _key: &str, _value: Vec<u8>) -> StoreResult<()> {
-                Ok(())
-            }
-
-            async fn remove(&self, _key: &str) -> StoreResult<()> {
-                Ok(())
-            }
-
-            async fn exists(&self, key: &str) -> StoreResult<bool> {
-                Ok(self.files.contains_key(key))
-            }
-
-            async fn generate_upload_url(
-                &self,
-                _key: &str,
-                _content_type: Option<&str>,
-                _content_length: Option<u64>,
-            ) -> StoreResult<Option<String>> {
-                Ok(Some("http://mock-upload-url".to_string()))
-            }
-
-            async fn generate_download_url(&self, _key: &str) -> StoreResult<Option<String>> {
-                Ok(Some("http://mock-download-url".to_string()))
-            }
-        }
+        use crate::test_util::PresignedStore;
 
         // Create a mock authenticator
         let mut authenticator = y_sweet_core::auth::Authenticator::gen_key().unwrap();
@@ -2909,12 +2834,11 @@ mod test {
             .unwrap();
 
         // Set up the mock store with the test file
-        let mut mock_files = HashMap::new();
-        mock_files.insert(format!("files/{}/{}", doc_id, file_hash), vec![1, 2, 3, 4]);
-
-        let mock_store = MockStore {
-            files: Arc::new(mock_files),
-        };
+        let mock_store = PresignedStore::new();
+        mock_store
+            .set(&format!("files/{}/{}", doc_id, file_hash), vec![1, 2, 3, 4])
+            .await
+            .unwrap();
 
         // Create the server with our mock components
         let server_state = Arc::new(
@@ -3298,9 +3222,10 @@ mod test {
 
     /// Test that persistence workers terminate when docs are garbage collected.
     /// This is a regression test for the memory leak fixed in PR #401.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_persistence_worker_terminates_on_gc() {
-        // Use a very short checkpoint frequency to speed up the test
+        // Paused time auto-advances through the worker sleeps, so the
+        // checkpoint frequency costs nothing in wall-clock terms.
         let checkpoint_freq = Duration::from_millis(50);
 
         let server = Arc::new(
@@ -3346,6 +3271,180 @@ mod test {
             wait_result.is_ok(),
             "Persistence workers should terminate after GC, but they hung"
         );
+    }
+
+    /// Characterization tests for the current document lifecycle. These pin
+    /// behavior that must survive the lifecycle redesign; they are written
+    /// against the current implementation and must stay green through
+    /// every migration step.
+    mod lifecycle_characterization {
+        use super::*;
+        use crate::test_util::{test_server, GatedStore};
+        use y_sweet_core::store::memory::MemoryStore;
+        use yrs::{Map, Out, ReadTxn, Transact};
+
+        /// A v1 update inserting `value` under `key` in the "data" map.
+        fn content_update(key: &str, value: &str) -> Vec<u8> {
+            let doc = yrs::Doc::new();
+            let map = doc.get_or_insert_map("data");
+            {
+                let mut txn = doc.transact_mut();
+                map.insert(&mut txn, key, value);
+            }
+            let txn = doc.transact();
+            txn.encode_state_as_update_v1(&yrs::StateVector::default())
+        }
+
+        fn read_content(dwskv: &DocWithSyncKv, key: &str) -> Option<String> {
+            let awareness = dwskv.awareness();
+            let awareness = awareness.read().unwrap();
+            let doc = awareness.doc();
+            let txn = doc.transact();
+            let map = txn.get_map("data")?;
+            match map.get(&txn, key) {
+                Some(Out::Any(yrs::Any::String(s))) => Some(s.to_string()),
+                _ => None,
+            }
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn evicted_doc_state_survives_reload() {
+            let store = MemoryStore::new();
+            let server = test_server(
+                Some(Box::new(store.clone())),
+                Duration::from_millis(10),
+                true,
+                CancellationToken::new(),
+            )
+            .await;
+
+            let doc_id = server.create_doc().await.unwrap();
+            {
+                // Scope the map ref: it holds a shard guard the GC's
+                // eviction needs.
+                let dwskv = server.get_or_create_doc(&doc_id).await.unwrap();
+                dwskv.apply_update(&content_update("k", "v")).unwrap();
+            }
+
+            // The GC needs two idle probes plus the eviction pass; paused
+            // time auto-advances through the worker sleeps.
+            for _ in 0..50 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                if !server.docs.contains_key(&doc_id) {
+                    break;
+                }
+            }
+            assert!(
+                !server.docs.contains_key(&doc_id),
+                "doc should have been GC-evicted"
+            );
+
+            let dwskv = server.get_or_create_doc(&doc_id).await.unwrap();
+            assert_eq!(
+                read_content(&dwskv, "k").as_deref(),
+                Some("v"),
+                "state written before eviction must survive the reload"
+            );
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn held_awareness_ref_prevents_gc() {
+            let server = test_server(
+                None,
+                Duration::from_millis(10),
+                true,
+                CancellationToken::new(),
+            )
+            .await;
+
+            let doc_id = server.create_doc().await.unwrap();
+            let _held = server.get_or_create_doc(&doc_id).await.unwrap().awareness();
+
+            // Many multiples of the two-probe GC cadence.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert!(
+                server.docs.contains_key(&doc_id),
+                "a held awareness ref is the current liveness contract; GC must not evict"
+            );
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn http_update_persisted_within_checkpoint_freq() {
+            let checkpoint_freq = Duration::from_secs(10);
+            let store = MemoryStore::new();
+            let server = Arc::new(
+                test_server(
+                    Some(Box::new(store.clone())),
+                    checkpoint_freq,
+                    false,
+                    CancellationToken::new(),
+                )
+                .await,
+            );
+
+            let doc_id = server.create_doc().await.unwrap();
+            let key = format!("{doc_id}/data.ysweet");
+            // A fresh doc is clean, so the initial persist is a no-op and
+            // the key may not exist yet.
+            let baseline = store.get_bytes(&key);
+
+            update_doc_inner(
+                doc_id.clone(),
+                server.clone(),
+                Authorization::Full,
+                Bytes::from(content_update("k", "v")),
+            )
+            .await
+            .unwrap();
+
+            tokio::time::sleep(checkpoint_freq + Duration::from_secs(1)).await;
+
+            let after = store
+                .get_bytes(&key)
+                .expect("an HTTP update must reach the store within checkpoint_freq");
+            assert_ne!(baseline, Some(after));
+            let dwskv = server.get_or_create_doc(&doc_id).await.unwrap();
+            assert!(!dwskv.sync_kv().is_dirty());
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn concurrent_first_loads_hit_store_once() {
+            let store = GatedStore::new();
+            let server = Arc::new(
+                test_server(
+                    Some(Box::new(store.clone())),
+                    Duration::from_secs(10),
+                    false,
+                    CancellationToken::new(),
+                )
+                .await,
+            );
+
+            let doc_id = "same-doc";
+            let awareness_refs = futures::future::join_all((0..8).map(|_| {
+                let server = server.clone();
+                async move {
+                    let dwskv = server.get_or_create_doc(doc_id).await.unwrap();
+                    dwskv.awareness()
+                }
+            }))
+            .await;
+
+            let key = format!("{doc_id}/data.ysweet");
+            assert_eq!(
+                store.get_count(&key),
+                1,
+                "concurrent first loads must single-flight the store read"
+            );
+
+            let first = &awareness_refs[0];
+            for awareness in &awareness_refs[1..] {
+                assert!(
+                    Arc::ptr_eq(first, awareness),
+                    "all concurrent loaders must see the same instance"
+                );
+            }
+        }
     }
 
     mod socket_teardown {

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -18,7 +18,7 @@ use axum::{
 };
 use axum_extra::typed_header::TypedHeader;
 use dashmap::{mapref::one::MappedRef, DashMap};
-use futures::{SinkExt, StreamExt, TryStreamExt};
+use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -31,7 +31,7 @@ use tempfile::NamedTempFile;
 use tokio::{
     net::TcpListener,
     sync::{
-        mpsc::{channel, Receiver},
+        mpsc::{channel, error::TrySendError, Receiver},
         Mutex as AsyncMutex,
     },
 };
@@ -234,6 +234,10 @@ pub struct Server {
     url: Option<Url>,
     allowed_hosts: Vec<AllowedHost>,
     cancellation_token: CancellationToken,
+    /// Child of cancellation_token that doc socket loops watch. Firing it
+    /// alone closes every doc WebSocket without stopping anything else, so
+    /// shutdown can clear the sockets before axum's graceful drain starts.
+    doc_close_token: CancellationToken,
     /// Whether to garbage collect docs that are no longer in use.
     doc_gc: bool,
     event_dispatcher: Option<Arc<dyn EventDispatcher>>,
@@ -299,12 +303,23 @@ impl Server {
             authenticator,
             url,
             allowed_hosts,
+            doc_close_token: cancellation_token.child_token(),
             cancellation_token,
             doc_gc,
             event_dispatcher,
             sync_protocol_event_sender,
             metrics,
         })
+    }
+
+    /// Close every doc WebSocket: each socket loop breaks, sends its
+    /// client a going-away close frame, and lets its connection task
+    /// finish — so a graceful HTTP drain started afterwards has nothing
+    /// left to wait for. Cancelling the server token also fires this (the
+    /// close token is its child); calling this first merely orders the
+    /// socket close ahead of the drain.
+    pub fn close_doc_sockets(&self) {
+        self.doc_close_token.cancel();
     }
 
     /// First beat of the client-compatible shutdown drain: persist every
@@ -527,6 +542,7 @@ impl Server {
                 self.doc_worker_tracker.spawn(
                     Self::doc_gc_worker(
                         self.docs.clone(),
+                        self.loading_locks.clone(),
                         doc_id.clone(),
                         checkpoint_freq,
                         cancellation_token,
@@ -542,6 +558,7 @@ impl Server {
 
     async fn doc_gc_worker(
         docs: Arc<DashMap<String, DocWithSyncKv>>,
+        loading_locks: Arc<DashMap<String, Arc<AsyncMutex<()>>>>,
         doc_id: String,
         checkpoint_freq: Duration,
         cancellation_token: CancellationToken,
@@ -565,23 +582,56 @@ impl Server {
                     }
 
                     if checkpoints_without_refs >= 2 {
-                        tracing::info!("GCing doc");
-                        if let Some(doc) = docs.get(&doc_id) {
-                            // Compact PUD before shutdown: dedup ids, clear ds.
-                            // The mutations create tombstones which yrs GC will
-                            // clean up, and the update observer marks SyncKv
-                            // dirty so the compacted state gets persisted.
-                            let result = doc.compact_user_data();
-                            if !result.is_empty() {
-                                tracing::debug!(
-                                    ids_removed = result.ids_removed,
-                                    ds_removed = result.ds_removed,
-                                    "Compacted PermanentUserData"
-                                );
-                            }
-                            doc.sync_kv().shutdown();
+                        // Eviction is atomic with respect to attachment: it
+                        // holds the same per-doc lock ensure_doc_loaded takes,
+                        // so a loader either finds the doc in the map or
+                        // waits until the store already holds the final
+                        // flush.
+                        let lock = {
+                            let entry = loading_locks
+                                .entry(doc_id.clone())
+                                .or_insert_with(|| Arc::new(AsyncMutex::new(())));
+                            Arc::clone(entry.value())
+                        };
+                        let _guard = lock.lock().await;
+
+                        let Some((_, doc)) = docs.remove(&doc_id) else {
+                            break;
+                        };
+                        // A connection may have attached between the idle
+                        // checks and taking the lock; it holds awareness
+                        // refs. Un-evict rather than orphan it on an
+                        // instance the map no longer knows: an orphan's
+                        // updates dispatch only to its own instance and are
+                        // invisible to every later connection.
+                        let probe = Arc::downgrade(&doc.awareness());
+                        if probe.strong_count() > 1 {
+                            tracing::info!("attach raced GC; un-evicting doc");
+                            docs.insert(doc_id.clone(), doc);
+                            checkpoints_without_refs = 0;
+                            continue;
                         }
-                        docs.remove(&doc_id);
+                        tracing::info!("GCing doc");
+                        // Compact PUD before shutdown: dedup ids, clear ds.
+                        // The mutations create tombstones which yrs GC will
+                        // clean up, and the update observer marks SyncKv
+                        // dirty so the compacted state gets persisted.
+                        let result = doc.compact_user_data();
+                        if !result.is_empty() {
+                            tracing::debug!(
+                                ids_removed = result.ids_removed,
+                                ds_removed = result.ds_removed,
+                                "Compacted PermanentUserData"
+                            );
+                        }
+                        // The final state must reach the store before the
+                        // loading lock releases: a reload racing a
+                        // fire-and-forget flush loads a stale snapshot and
+                        // its next persist rolls the doc back.
+                        if let Err(e) = doc.sync_kv().persist().await {
+                            tracing::error!(?e, "Error persisting during GC eviction");
+                        }
+                        doc.sync_kv().shutdown();
                         break;
                     }
                 }
@@ -1051,7 +1101,9 @@ async fn handle_socket_upgrade_with_channel_and_user(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     let awareness = dwskv.awareness();
     let sync_kv = dwskv.sync_kv();
-    let cancellation_token = server_state.cancellation_token.clone();
+    // Socket loops watch the doc-close token (a child of the server token)
+    // so shutdown can close them ahead of the graceful drain.
+    let cancellation_token = server_state.doc_close_token.clone();
     let sync_protocol_event_sender = server_state.sync_protocol_event_sender.clone();
     let metrics = server_state.metrics.clone();
     let doc_id_clone = doc_id.clone();
@@ -1197,23 +1249,83 @@ async fn handle_socket(
     doc_id: String,
     metrics: Arc<RelayMetrics>,
 ) {
-    let (mut sink, mut stream) = socket.split();
+    let (sink, stream) = socket.split();
+    handle_socket_inner(
+        sink,
+        stream,
+        awareness,
+        sync_kv,
+        authorization,
+        expiration_time,
+        user,
+        cancellation_token,
+        sync_protocol_event_sender,
+        doc_id,
+        metrics,
+    )
+    .await
+}
+
+/// Generic over the socket halves so teardown behavior can be tested without
+/// a real WebSocket upgrade.
+#[allow(clippy::too_many_arguments)]
+async fn handle_socket_inner<S, T, E>(
+    mut sink: S,
+    mut stream: T,
+    awareness: Arc<RwLock<Awareness>>,
+    sync_kv: Arc<SyncKv>,
+    authorization: Authorization,
+    expiration_time: Option<u64>,
+    user: Option<String>,
+    cancellation_token: CancellationToken,
+    sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
+    doc_id: String,
+    metrics: Arc<RelayMetrics>,
+) where
+    S: Sink<Message> + Send + Unpin + 'static,
+    T: Stream<Item = Result<Message, E>> + Unpin,
+    E: std::fmt::Debug,
+{
     let (send, mut recv) = channel(1024);
+
+    // Cancelled when the writer task exits (sink write failure) or when the
+    // parent server token cancels. The read loop selects on it so the
+    // connection is torn down instead of being held forever on a socket that
+    // can no longer be written to.
+    let conn_token = cancellation_token.child_token();
+    let sink_token = conn_token.clone();
 
     tokio::spawn(async move {
         while let Some(msg) = recv.recv().await {
-            let _ = sink.send(msg).await;
+            if sink.send(msg).await.is_err() {
+                break;
+            }
         }
+        sink_token.cancel();
     });
 
     let send_clone = send.clone();
+    let metrics_clone = metrics.clone();
     let mut conn = DocConnection::new_with_expiration(
         awareness,
         authorization,
         expiration_time,
         move |bytes| {
-            if let Err(e) = send_clone.try_send(Message::Binary(bytes.to_vec())) {
-                tracing::warn!(?e, "Error sending message");
+            match send_clone.try_send(Message::Binary(bytes.to_vec())) {
+                Ok(()) => {}
+                Err(TrySendError::Closed(_)) => {
+                    // The writer task has exited; the read loop tears the
+                    // connection down as soon as it sees the cancelled token,
+                    // so this is a brief race, not an error.
+                    metrics_clone.record_websocket_send_failure("closed");
+                    tracing::debug!("Dropping outbound message: writer task exited");
+                }
+                Err(e @ TrySendError::Full(_)) => {
+                    // A dropped update silently desyncs this client until it
+                    // reconnects; the metric tracks how often that happens.
+                    metrics_clone.record_websocket_send_failure("full");
+                    tracing::warn!(?e, "Outbound channel full; dropping message");
+                }
             }
         },
     );
@@ -1226,12 +1338,16 @@ async fn handle_socket(
     // Register the connection with the sync protocol event sender
     sync_protocol_event_sender.register_doc_connection(doc_id.clone(), Arc::downgrade(&connection));
 
-    loop {
+    let close_reason = loop {
         tokio::select! {
-            Some(msg) = stream.next() => {
+            msg = stream.next() => {
+                let Some(msg) = msg else {
+                    // The stream ended without a close handshake.
+                    break "stream_eof";
+                };
                 let msg = match msg {
                     Ok(Message::Binary(bytes)) => bytes,
-                    Ok(Message::Close(_)) => break,
+                    Ok(Message::Close(_)) => break "close_frame",
                     Err(_e) => {
                         // The stream will complain about things like
                         // connections being lost without handshake.
@@ -1260,19 +1376,31 @@ async fn handle_socket(
                             code: 1008, // Policy Violation - indicates a policy violation
                             reason: "Token expired".into(),
                         })));
-                        break;
+                        break "token_expired";
                     }
                     Err(e) => {
                         tracing::warn!(?e, "Error handling message");
                     }
                 }
             }
-            _ = cancellation_token.cancelled() => {
-                tracing::debug!("Closing doc connection due to server cancel...");
-                break;
+            _ = conn_token.cancelled() => {
+                if cancellation_token.is_cancelled() {
+                    tracing::debug!("Closing doc connection due to server cancel...");
+                    // A proper close handshake instead of an abrupt drop:
+                    // the writer task drains this frame before it exits.
+                    let _ = send.try_send(Message::Close(Some(CloseFrame {
+                        code: 1001, // Going Away
+                        reason: "server shutting down".into(),
+                    })));
+                    break "server_shutdown";
+                }
+                // The child token only cancels from the writer task.
+                break "sink_error";
             }
         }
-    }
+    };
+
+    metrics.record_websocket_close(close_reason);
 }
 
 async fn check_store(
@@ -3150,6 +3278,166 @@ mod test {
             wait_result.is_ok(),
             "Persistence workers should terminate after GC, but they hung"
         );
+    }
+
+    mod socket_teardown {
+        use super::*;
+        use futures::channel::mpsc as futures_mpsc;
+        use tokio_stream::wrappers::ReceiverStream;
+        use y_sweet_core::sync::Message as SyncMessage;
+        use yrs::updates::encoder::Encode;
+
+        struct SocketHarness {
+            to_server: tokio::sync::mpsc::Sender<Result<Message, axum::Error>>,
+            from_server: futures_mpsc::UnboundedReceiver<Message>,
+            awareness: Arc<RwLock<Awareness>>,
+            metrics: Arc<RelayMetrics>,
+            task: tokio::task::JoinHandle<()>,
+        }
+
+        /// Run handle_socket_inner against in-memory socket halves so
+        /// teardown behavior is observable without a WebSocket upgrade.
+        async fn spawn_socket(server_token: CancellationToken) -> SocketHarness {
+            let (to_server, stream_rx) =
+                tokio::sync::mpsc::channel::<Result<Message, axum::Error>>(64);
+            let (sink_tx, from_server) = futures_mpsc::unbounded::<Message>();
+            let awareness = Arc::new(RwLock::new(Awareness::new(yrs::Doc::new())));
+            let metrics = RelayMetrics::new_with_registry(&prometheus::Registry::new()).unwrap();
+            let sync_kv = Arc::new(SyncKv::new(None, "test_doc", || ()).await.unwrap());
+
+            let task = tokio::spawn(handle_socket_inner(
+                sink_tx,
+                ReceiverStream::new(stream_rx),
+                awareness.clone(),
+                sync_kv,
+                Authorization::Full,
+                None,
+                None,
+                server_token,
+                Arc::new(SyncProtocolEventSender::new()),
+                "test_doc".to_string(),
+                metrics.clone(),
+            ));
+
+            SocketHarness {
+                to_server,
+                from_server,
+                awareness,
+                metrics,
+                task,
+            }
+        }
+
+        /// A y-sync awareness update announcing one client, as a client
+        /// connection would send it.
+        fn awareness_update_message() -> Vec<u8> {
+            let mut client = Awareness::new(yrs::Doc::new());
+            client.set_local_state(r#"{"user":"test"}"#);
+            let update = client.update().unwrap();
+            SyncMessage::Awareness(update).encode_v1()
+        }
+
+        fn closes(metrics: &RelayMetrics, reason: &str) -> f64 {
+            metrics
+                .websocket_closes_total
+                .with_label_values(&[reason])
+                .get()
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn stream_eof_tears_down_connection_and_clears_awareness() {
+            let harness = spawn_socket(CancellationToken::new()).await;
+            let base_clients = harness.awareness.read().unwrap().clients().len();
+
+            harness
+                .to_server
+                .send(Ok(Message::Binary(awareness_update_message())))
+                .await
+                .unwrap();
+
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    if harness.awareness.read().unwrap().clients().len() == base_clients + 1 {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("client awareness state was never applied");
+
+            // End the stream without a close handshake, as a vanished client
+            // whose TCP connection got reset would.
+            drop(harness.to_server);
+
+            tokio::time::timeout(Duration::from_secs(5), harness.task)
+                .await
+                .expect("read loop kept running after stream EOF")
+                .unwrap();
+
+            assert_eq!(
+                harness.awareness.read().unwrap().clients().len(),
+                base_clients,
+                "DocConnection drop should remove the client's awareness state"
+            );
+            assert_eq!(closes(&harness.metrics, "stream_eof"), 1.0);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn sink_error_tears_down_connection() {
+            let harness = spawn_socket(CancellationToken::new()).await;
+
+            // Kill the outbound half; the next write (initial sync or the
+            // first keepalive ping) fails, and the writer task must cancel
+            // the read loop rather than leave it parked forever.
+            drop(harness.from_server);
+
+            tokio::time::timeout(Duration::from_secs(60), harness.task)
+                .await
+                .expect("read loop kept running after sink write failure")
+                .unwrap();
+
+            assert_eq!(closes(&harness.metrics, "sink_error"), 1.0);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn server_cancel_closes_connection() {
+            let server_token = CancellationToken::new();
+            let harness = spawn_socket(server_token.clone()).await;
+
+            server_token.cancel();
+
+            tokio::time::timeout(Duration::from_secs(5), harness.task)
+                .await
+                .expect("read loop kept running after server cancel")
+                .unwrap();
+
+            assert_eq!(closes(&harness.metrics, "server_shutdown"), 1.0);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn server_cancel_sends_going_away_close_frame() {
+            let server_token = CancellationToken::new();
+            let mut harness = spawn_socket(server_token.clone()).await;
+
+            server_token.cancel();
+
+            tokio::time::timeout(Duration::from_secs(5), harness.task)
+                .await
+                .expect("read loop kept running after server cancel")
+                .unwrap();
+
+            // The client sees a proper close handshake, not an abrupt
+            // drop: the last frame the writer sends is Close(1001).
+            let mut last_close = None;
+            while let Ok(Some(msg)) = harness.from_server.try_next() {
+                if let Message::Close(frame) = msg {
+                    last_close = frame;
+                }
+            }
+            let frame = last_close.expect("no close frame reached the client");
+            assert_eq!(frame.code, 1001);
+        }
     }
 }
 

--- a/crates/relay/src/test_util.rs
+++ b/crates/relay/src/test_util.rs
@@ -12,7 +12,9 @@ use std::sync::{
 use std::time::Duration;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
+use y_sweet_core::doc_sync::DocWithSyncKv;
 use y_sweet_core::store::{memory::MemoryStore, Result as StoreResult, Store};
+use yrs::{Map, Out, ReadTxn, Transact};
 
 /// A `MemoryStore` wrapper that counts reads/writes per key and can hold
 /// every `set` on a gate, so tests can freeze a persist mid-flight and
@@ -200,6 +202,31 @@ impl Store for PresignedStore {
 
     async fn generate_download_url(&self, _key: &str) -> StoreResult<Option<String>> {
         Ok(Some(self.download_url.to_string()))
+    }
+}
+
+/// A v1 update inserting `value` under `key` in the "data" map.
+pub(crate) fn content_update(key: &str, value: &str) -> Vec<u8> {
+    let doc = yrs::Doc::new();
+    let map = doc.get_or_insert_map("data");
+    {
+        let mut txn = doc.transact_mut();
+        map.insert(&mut txn, key, value);
+    }
+    let txn = doc.transact();
+    txn.encode_state_as_update_v1(&yrs::StateVector::default())
+}
+
+/// Read back a string inserted with [`content_update`].
+pub(crate) fn read_content(dwskv: &DocWithSyncKv, key: &str) -> Option<String> {
+    let awareness = dwskv.awareness();
+    let awareness = awareness.read().unwrap();
+    let doc = awareness.doc();
+    let txn = doc.transact();
+    let map = txn.get_map("data")?;
+    match map.get(&txn, key) {
+        Some(Out::Any(yrs::Any::String(s))) => Some(s.to_string()),
+        _ => None,
     }
 }
 

--- a/crates/relay/src/test_util.rs
+++ b/crates/relay/src/test_util.rs
@@ -1,0 +1,224 @@
+//! Shared test fixtures for lifecycle tests: deterministic store wrappers
+//! and a server builder. Fixtures only — tests stay inline in the files
+//! they cover.
+
+use crate::server::Server;
+use async_trait::async_trait;
+use dashmap::DashMap;
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use y_sweet_core::store::{memory::MemoryStore, Result as StoreResult, Store};
+
+/// A `MemoryStore` wrapper that counts reads/writes per key and can hold
+/// every `set` on a gate, so tests can freeze a persist mid-flight and
+/// order other work around it deterministically (no sleeps).
+#[derive(Clone)]
+pub(crate) struct GatedStore {
+    inner: MemoryStore,
+    gated: Arc<AtomicBool>,
+    gate: Arc<Semaphore>,
+    gets: Arc<DashMap<String, usize>>,
+    puts: Arc<DashMap<String, usize>>,
+}
+
+impl GatedStore {
+    pub fn new() -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            gated: Arc::new(AtomicBool::new(false)),
+            gate: Arc::new(Semaphore::new(0)),
+            gets: Arc::new(DashMap::new()),
+            puts: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Hold every subsequent `set` until `release` or `open`.
+    pub fn close_gate(&self) {
+        self.gated.store(true, Ordering::SeqCst);
+    }
+
+    /// Let `n` held/future `set`s through.
+    pub fn release(&self, n: usize) {
+        self.gate.add_permits(n);
+    }
+
+    /// Stop gating entirely and unblock everything held.
+    pub fn open_gate(&self) {
+        self.gated.store(false, Ordering::SeqCst);
+        self.gate
+            .add_permits(Semaphore::MAX_PERMITS - self.gate.available_permits());
+    }
+
+    pub fn get_count(&self, key: &str) -> usize {
+        self.gets.get(key).map(|v| *v).unwrap_or(0)
+    }
+
+    pub fn put_count(&self, key: &str) -> usize {
+        self.puts.get(key).map(|v| *v).unwrap_or(0)
+    }
+
+    /// Bytes currently stored for `key` (bypasses the gate).
+    pub fn stored(&self, key: &str) -> Option<Vec<u8>> {
+        self.inner.get_bytes(key)
+    }
+}
+
+#[async_trait]
+impl Store for GatedStore {
+    async fn init(&self) -> StoreResult<()> {
+        self.inner.init().await
+    }
+
+    async fn get(&self, key: &str) -> StoreResult<Option<Vec<u8>>> {
+        *self.gets.entry(key.to_owned()).or_insert(0) += 1;
+        self.inner.get(key).await
+    }
+
+    async fn set(&self, key: &str, value: Vec<u8>) -> StoreResult<()> {
+        if self.gated.load(Ordering::SeqCst) {
+            // Waiters queue here until the test releases the gate. The
+            // permit is intentionally consumed: one release() == one PUT.
+            let permit = self.gate.acquire().await.expect("gate semaphore closed");
+            permit.forget();
+        }
+        *self.puts.entry(key.to_owned()).or_insert(0) += 1;
+        self.inner.set(key, value).await
+    }
+
+    async fn remove(&self, key: &str) -> StoreResult<()> {
+        self.inner.remove(key).await
+    }
+
+    async fn exists(&self, key: &str) -> StoreResult<bool> {
+        self.inner.exists(key).await
+    }
+}
+
+/// A `MemoryStore` wrapper that fails the next `n` reads, for exercising
+/// load-failure paths.
+#[derive(Clone)]
+pub(crate) struct FailStore {
+    inner: MemoryStore,
+    fail_gets: Arc<AtomicUsize>,
+}
+
+impl FailStore {
+    pub fn new(fail_gets: usize) -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            fail_gets: Arc::new(AtomicUsize::new(fail_gets)),
+        }
+    }
+}
+
+#[async_trait]
+impl Store for FailStore {
+    async fn init(&self) -> StoreResult<()> {
+        self.inner.init().await
+    }
+
+    async fn get(&self, key: &str) -> StoreResult<Option<Vec<u8>>> {
+        if self
+            .fail_gets
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+            .is_ok()
+        {
+            return Err(y_sweet_core::store::StoreError::ConnectionError(format!(
+                "injected failure reading {key}"
+            )));
+        }
+        self.inner.get(key).await
+    }
+
+    async fn set(&self, key: &str, value: Vec<u8>) -> StoreResult<()> {
+        self.inner.set(key, value).await
+    }
+
+    async fn remove(&self, key: &str) -> StoreResult<()> {
+        self.inner.remove(key).await
+    }
+
+    async fn exists(&self, key: &str) -> StoreResult<bool> {
+        self.inner.exists(key).await
+    }
+}
+
+/// A `MemoryStore` that also hands out fixed presigned URLs, for file
+/// endpoint tests.
+#[derive(Clone)]
+pub(crate) struct PresignedStore {
+    inner: MemoryStore,
+    pub upload_url: &'static str,
+    pub download_url: &'static str,
+}
+
+impl PresignedStore {
+    pub fn new() -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            upload_url: "http://mock-upload-url",
+            download_url: "http://mock-download-url",
+        }
+    }
+}
+
+#[async_trait]
+impl Store for PresignedStore {
+    async fn init(&self) -> StoreResult<()> {
+        self.inner.init().await
+    }
+
+    async fn get(&self, key: &str) -> StoreResult<Option<Vec<u8>>> {
+        self.inner.get(key).await
+    }
+
+    async fn set(&self, key: &str, value: Vec<u8>) -> StoreResult<()> {
+        self.inner.set(key, value).await
+    }
+
+    async fn remove(&self, key: &str) -> StoreResult<()> {
+        self.inner.remove(key).await
+    }
+
+    async fn exists(&self, key: &str) -> StoreResult<bool> {
+        self.inner.exists(key).await
+    }
+
+    async fn generate_upload_url(
+        &self,
+        _key: &str,
+        _content_type: Option<&str>,
+        _content_length: Option<u64>,
+    ) -> StoreResult<Option<String>> {
+        Ok(Some(self.upload_url.to_string()))
+    }
+
+    async fn generate_download_url(&self, _key: &str) -> StoreResult<Option<String>> {
+        Ok(Some(self.download_url.to_string()))
+    }
+}
+
+pub(crate) async fn test_server(
+    store: Option<Box<dyn Store>>,
+    checkpoint_freq: Duration,
+    doc_gc: bool,
+    token: CancellationToken,
+) -> Server {
+    Server::new(
+        store,
+        checkpoint_freq,
+        None,
+        None,
+        vec![],
+        token,
+        doc_gc,
+        None,
+    )
+    .await
+    .expect("test server construction failed")
+}

--- a/crates/y-sweet-core/Cargo.toml
+++ b/crates/y-sweet-core/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "1.0.44"
 toml = "0.8"
 coset = "0.3.7"
 ciborium = "0.2.2"
+dashmap = "6.0.1"
 p256 = "0.13.2"
 ecdsa = "0.16.9"
 ed25519-dalek = { version = "2.1.1", features = ["pkcs8", "pem"] }
@@ -48,4 +49,3 @@ prometheus = "0.13"
 
 [dev-dependencies]
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
-dashmap = "6.0.1"

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -421,7 +421,12 @@ impl DocConnection {
                     let client_id = update.clients.keys().next().unwrap();
                     self.client_id.get_or_init(|| *client_id);
                 } else {
-                    tracing::warn!("Received awareness update with more than one client");
+                    tracing::warn!(
+                        user = ?self.user,
+                        connection_client_id = ?self.client_id.get(),
+                        update_client_ids = ?update.clients.keys().collect::<Vec<_>>(),
+                        "Received awareness update with more than one client"
+                    );
                 }
                 let mut awareness = a.write().unwrap();
                 protocol.handle_awareness_update(&mut awareness, update)

--- a/crates/y-sweet-core/src/metrics.rs
+++ b/crates/y-sweet-core/src/metrics.rs
@@ -31,6 +31,10 @@ pub struct RelayMetrics {
     pub websocket_pong_recoveries_total: CounterVec,
     pub websocket_send_failures_total: CounterVec,
     pub doc_dirty_at_drain_total: CounterVec,
+
+    // Document lifecycle metrics
+    pub doc_lifecycle_transitions_total: CounterVec,
+    pub lifecycle_accounting_mismatch_total: CounterVec,
 }
 
 static RELAY_METRICS: OnceLock<Result<Arc<RelayMetrics>, prometheus::Error>> = OnceLock::new();
@@ -227,6 +231,27 @@ impl RelayMetrics {
         // distinguishable from "no data".
         doc_dirty_at_drain_total.with_label_values(&[]);
 
+        let doc_lifecycle_transitions_total = CounterVec::new(
+            Opts::new(
+                "relay_server_doc_lifecycle_transitions_total",
+                "Document lifecycle state transitions, labeled by the states involved",
+            ),
+            &["from", "to"],
+        )?;
+        registry.register(Box::new(doc_lifecycle_transitions_total.clone()))?;
+
+        let lifecycle_accounting_mismatch_total = CounterVec::new(
+            Opts::new(
+                "relay_server_lifecycle_accounting_mismatch_total",
+                "Shadow-accounting soak: ticks where explicit attach/detach counts disagreed with the awareness strong-count probe across two consecutive checks. Must stay 0 before eviction switches to the explicit counts",
+            ),
+            &[],
+        )?;
+        registry.register(Box::new(lifecycle_accounting_mismatch_total.clone()))?;
+        // Touch so it exports 0 from startup; "no drift" must be
+        // distinguishable from "no data".
+        lifecycle_accounting_mismatch_total.with_label_values(&[]);
+
         Ok(Arc::new(Self {
             webhook_requests_total,
             webhook_request_duration_seconds,
@@ -247,6 +272,8 @@ impl RelayMetrics {
             websocket_pong_recoveries_total,
             websocket_send_failures_total,
             doc_dirty_at_drain_total,
+            doc_lifecycle_transitions_total,
+            lifecycle_accounting_mismatch_total,
         }))
     }
 
@@ -367,6 +394,18 @@ impl RelayMetrics {
 
     pub fn record_doc_dirty_at_drain(&self) {
         self.doc_dirty_at_drain_total.with_label_values(&[]).inc();
+    }
+
+    pub fn record_lifecycle_transition(&self, from: &str, to: &str) {
+        self.doc_lifecycle_transitions_total
+            .with_label_values(&[from, to])
+            .inc();
+    }
+
+    pub fn record_lifecycle_accounting_mismatch(&self) {
+        self.lifecycle_accounting_mismatch_total
+            .with_label_values(&[])
+            .inc();
     }
 
     pub fn record_websocket_send_failure(&self, kind: &str) {

--- a/crates/y-sweet-core/src/metrics.rs
+++ b/crates/y-sweet-core/src/metrics.rs
@@ -27,6 +27,8 @@ pub struct RelayMetrics {
 
     // WebSocket connection lifecycle metrics
     pub websocket_closes_total: CounterVec,
+    pub websocket_pong_timeouts_total: CounterVec,
+    pub websocket_pong_recoveries_total: CounterVec,
     pub websocket_send_failures_total: CounterVec,
 }
 
@@ -181,6 +183,28 @@ impl RelayMetrics {
         )?;
         registry.register(Box::new(websocket_closes_total.clone()))?;
 
+        let websocket_pong_timeouts_total = CounterVec::new(
+            Opts::new(
+                "relay_server_websocket_pong_timeouts_total",
+                "Connections that went silent past the pong timeout. Observe-only: a keepalive reaper would have closed these",
+            ),
+            &[],
+        )?;
+        registry.register(Box::new(websocket_pong_timeouts_total.clone()))?;
+        // Touch the label-less soak counters so they export 0 from startup;
+        // "no would-be reaps yet" must be distinguishable from "no data".
+        websocket_pong_timeouts_total.with_label_values(&[]);
+
+        let websocket_pong_recoveries_total = CounterVec::new(
+            Opts::new(
+                "relay_server_websocket_pong_recoveries_total",
+                "Connections that ponged again after exceeding the pong timeout. A keepalive reaper would have closed a live connection",
+            ),
+            &[],
+        )?;
+        registry.register(Box::new(websocket_pong_recoveries_total.clone()))?;
+        websocket_pong_recoveries_total.with_label_values(&[]);
+
         let websocket_send_failures_total = CounterVec::new(
             Opts::new(
                 "relay_server_websocket_send_failures_total",
@@ -206,6 +230,8 @@ impl RelayMetrics {
             http_auth_errors_total,
             s3_requests_total,
             websocket_closes_total,
+            websocket_pong_timeouts_total,
+            websocket_pong_recoveries_total,
             websocket_send_failures_total,
         }))
     }
@@ -310,6 +336,18 @@ impl RelayMetrics {
     pub fn record_websocket_close(&self, reason: &str) {
         self.websocket_closes_total
             .with_label_values(&[reason])
+            .inc();
+    }
+
+    pub fn record_pong_timeout(&self) {
+        self.websocket_pong_timeouts_total
+            .with_label_values(&[])
+            .inc();
+    }
+
+    pub fn record_pong_recovery(&self) {
+        self.websocket_pong_recoveries_total
+            .with_label_values(&[])
             .inc();
     }
 

--- a/crates/y-sweet-core/src/metrics.rs
+++ b/crates/y-sweet-core/src/metrics.rs
@@ -24,6 +24,10 @@ pub struct RelayMetrics {
 
     // Object store metrics
     pub s3_requests_total: CounterVec,
+
+    // WebSocket connection lifecycle metrics
+    pub websocket_closes_total: CounterVec,
+    pub websocket_send_failures_total: CounterVec,
 }
 
 static RELAY_METRICS: OnceLock<Result<Arc<RelayMetrics>, prometheus::Error>> = OnceLock::new();
@@ -167,6 +171,25 @@ impl RelayMetrics {
         )?;
         registry.register(Box::new(s3_requests_total.clone()))?;
 
+        // WebSocket connection lifecycle metrics
+        let websocket_closes_total = CounterVec::new(
+            Opts::new(
+                "relay_server_websocket_closes_total",
+                "Total number of WebSocket connection teardowns, labeled by cause",
+            ),
+            &["reason"],
+        )?;
+        registry.register(Box::new(websocket_closes_total.clone()))?;
+
+        let websocket_send_failures_total = CounterVec::new(
+            Opts::new(
+                "relay_server_websocket_send_failures_total",
+                "Outbound WebSocket messages dropped because the connection's send channel was full or closed",
+            ),
+            &["kind"],
+        )?;
+        registry.register(Box::new(websocket_send_failures_total.clone()))?;
+
         Ok(Arc::new(Self {
             webhook_requests_total,
             webhook_request_duration_seconds,
@@ -182,6 +205,8 @@ impl RelayMetrics {
             debounced_queue_length,
             http_auth_errors_total,
             s3_requests_total,
+            websocket_closes_total,
+            websocket_send_failures_total,
         }))
     }
 
@@ -278,6 +303,19 @@ impl RelayMetrics {
     pub fn record_s3_request(&self, method: &str, outcome: &str) {
         self.s3_requests_total
             .with_label_values(&[method, outcome])
+            .inc();
+    }
+
+    // WebSocket connection lifecycle metrics methods
+    pub fn record_websocket_close(&self, reason: &str) {
+        self.websocket_closes_total
+            .with_label_values(&[reason])
+            .inc();
+    }
+
+    pub fn record_websocket_send_failure(&self, kind: &str) {
+        self.websocket_send_failures_total
+            .with_label_values(&[kind])
             .inc();
     }
 }

--- a/crates/y-sweet-core/src/metrics.rs
+++ b/crates/y-sweet-core/src/metrics.rs
@@ -34,7 +34,6 @@ pub struct RelayMetrics {
 
     // Document lifecycle metrics
     pub doc_lifecycle_transitions_total: CounterVec,
-    pub lifecycle_accounting_mismatch_total: CounterVec,
 }
 
 static RELAY_METRICS: OnceLock<Result<Arc<RelayMetrics>, prometheus::Error>> = OnceLock::new();
@@ -240,18 +239,6 @@ impl RelayMetrics {
         )?;
         registry.register(Box::new(doc_lifecycle_transitions_total.clone()))?;
 
-        let lifecycle_accounting_mismatch_total = CounterVec::new(
-            Opts::new(
-                "relay_server_lifecycle_accounting_mismatch_total",
-                "Shadow-accounting soak: ticks where explicit attach/detach counts disagreed with the awareness strong-count probe across two consecutive checks. Must stay 0 before eviction switches to the explicit counts",
-            ),
-            &[],
-        )?;
-        registry.register(Box::new(lifecycle_accounting_mismatch_total.clone()))?;
-        // Touch so it exports 0 from startup; "no drift" must be
-        // distinguishable from "no data".
-        lifecycle_accounting_mismatch_total.with_label_values(&[]);
-
         Ok(Arc::new(Self {
             webhook_requests_total,
             webhook_request_duration_seconds,
@@ -273,7 +260,6 @@ impl RelayMetrics {
             websocket_send_failures_total,
             doc_dirty_at_drain_total,
             doc_lifecycle_transitions_total,
-            lifecycle_accounting_mismatch_total,
         }))
     }
 
@@ -399,12 +385,6 @@ impl RelayMetrics {
     pub fn record_lifecycle_transition(&self, from: &str, to: &str) {
         self.doc_lifecycle_transitions_total
             .with_label_values(&[from, to])
-            .inc();
-    }
-
-    pub fn record_lifecycle_accounting_mismatch(&self) {
-        self.lifecycle_accounting_mismatch_total
-            .with_label_values(&[])
             .inc();
     }
 

--- a/crates/y-sweet-core/src/metrics.rs
+++ b/crates/y-sweet-core/src/metrics.rs
@@ -30,6 +30,7 @@ pub struct RelayMetrics {
     pub websocket_pong_timeouts_total: CounterVec,
     pub websocket_pong_recoveries_total: CounterVec,
     pub websocket_send_failures_total: CounterVec,
+    pub doc_dirty_at_drain_total: CounterVec,
 }
 
 static RELAY_METRICS: OnceLock<Result<Arc<RelayMetrics>, prometheus::Error>> = OnceLock::new();
@@ -214,6 +215,18 @@ impl RelayMetrics {
         )?;
         registry.register(Box::new(websocket_send_failures_total.clone()))?;
 
+        let doc_dirty_at_drain_total = CounterVec::new(
+            Opts::new(
+                "relay_server_doc_dirty_at_drain_total",
+                "Docs whose last connection closed while unpersisted changes were still inside the checkpoint throttle — the window an unsignaled suspend would freeze dirty",
+            ),
+            &[],
+        )?;
+        registry.register(Box::new(doc_dirty_at_drain_total.clone()))?;
+        // Touch so it exports 0 from startup; "never raced" must be
+        // distinguishable from "no data".
+        doc_dirty_at_drain_total.with_label_values(&[]);
+
         Ok(Arc::new(Self {
             webhook_requests_total,
             webhook_request_duration_seconds,
@@ -233,6 +246,7 @@ impl RelayMetrics {
             websocket_pong_timeouts_total,
             websocket_pong_recoveries_total,
             websocket_send_failures_total,
+            doc_dirty_at_drain_total,
         }))
     }
 
@@ -349,6 +363,10 @@ impl RelayMetrics {
         self.websocket_pong_recoveries_total
             .with_label_values(&[])
             .inc();
+    }
+
+    pub fn record_doc_dirty_at_drain(&self) {
+        self.doc_dirty_at_drain_total.with_label_values(&[]).inc();
     }
 
     pub fn record_websocket_send_failure(&self, kind: &str) {

--- a/crates/y-sweet-core/src/store/memory.rs
+++ b/crates/y-sweet-core/src/store/memory.rs
@@ -1,0 +1,62 @@
+//! An in-memory [`Store`] backed by a shared map. Clones share the same
+//! underlying data, so a `MemoryStore` can stand in for a durable store
+//! shared between multiple servers in tests, or serve as an ephemeral
+//! store where durability is not required.
+//!
+//! The default `get_with_lease`/`set_if_unchanged` implementations give it
+//! digest-based compare-and-set semantics, matching the write-lease
+//! behavior of stores without native conditional writes.
+
+use super::{Result, Store};
+use async_trait::async_trait;
+use dashmap::DashMap;
+use std::sync::Arc;
+
+#[derive(Default, Clone)]
+pub struct MemoryStore {
+    data: Arc<DashMap<String, Vec<u8>>>,
+}
+
+impl MemoryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Direct (non-trait) read of a stored value, for assertions.
+    pub fn get_bytes(&self, key: &str) -> Option<Vec<u8>> {
+        self.data.get(key).map(|v| v.value().clone())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+#[async_trait]
+impl Store for MemoryStore {
+    async fn init(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        Ok(self.data.get(key).map(|v| v.value().clone()))
+    }
+
+    async fn set(&self, key: &str, value: Vec<u8>) -> Result<()> {
+        self.data.insert(key.to_owned(), value);
+        Ok(())
+    }
+
+    async fn remove(&self, key: &str) -> Result<()> {
+        self.data.remove(key);
+        Ok(())
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool> {
+        Ok(self.data.contains_key(key))
+    }
+}

--- a/crates/y-sweet-core/src/store/mod.rs
+++ b/crates/y-sweet-core/src/store/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub mod memory;
 pub mod s3;
 
 use async_trait::async_trait;

--- a/crates/y-sweet-core/src/sync_kv.rs
+++ b/crates/y-sweet-core/src/sync_kv.rs
@@ -229,7 +229,12 @@ impl SyncKv {
     }
 
     fn mark_dirty(&self) {
-        if !self.dirty.load(Ordering::Relaxed) && !self.shutdown.load(Ordering::SeqCst) {
+        // Writes after shutdown still mark dirty: a connection that raced
+        // eviction and kept writing must leave persist() something to
+        // save. The callback wake is best-effort — the persistence worker
+        // may already be gone — so the write's durability rests on the
+        // explicit persist() at connection teardown.
+        if !self.dirty.load(Ordering::Relaxed) {
             self.dirty.store(true, Ordering::Relaxed);
             (self.dirty_callback)();
         }
@@ -326,6 +331,11 @@ impl SyncKv {
 
     pub fn is_shutdown(&self) -> bool {
         self.shutdown.load(Ordering::SeqCst)
+    }
+
+    /// Whether local state has changes the store has not seen.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty.load(Ordering::Relaxed)
     }
 
     pub fn shutdown(&self) {

--- a/crates/y-sweet-core/src/sync_kv.rs
+++ b/crates/y-sweet-core/src/sync_kv.rs
@@ -138,14 +138,14 @@ impl SyncKv {
             write_lease = Some(leased.lease);
 
             if let Some(snapshot) = leased.value {
-                tracing::info!(size=?snapshot.len(), "Loading snapshot");
+                tracing::debug!(size=?snapshot.len(), "Loading snapshot");
 
                 // Try CBOR format first
                 match ciborium::de::from_reader::<YSweetData, _>(&snapshot[..]) {
                     Ok(y_data) => {
                         created_at = Some(y_data.created_at);
                         metadata = y_data.metadata;
-                        tracing::info!("Loaded CBOR format data (version {})", y_data.version);
+                        tracing::debug!("Loaded CBOR format data (version {})", y_data.version);
                         y_data.data
                     }
                     Err(cbor_err) => {
@@ -276,7 +276,7 @@ impl SyncKv {
                 buffer
             };
 
-            tracing::info!(size=?snapshot.len(), "Persisting CBOR snapshot");
+            tracing::debug!(size=?snapshot.len(), "Persisting CBOR snapshot");
             let result = if require_lease {
                 let lease = self.write_lease.lock().unwrap().clone().ok_or_else(|| {
                     crate::store::StoreError::UnsupportedOperation(format!(

--- a/crates/y-sweet-core/src/sync_kv.rs
+++ b/crates/y-sweet-core/src/sync_kv.rs
@@ -509,42 +509,9 @@ impl<'a> yrs_kvstore::KVStore<'a> for SyncKv {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::store::Result;
-    use async_trait::async_trait;
-    use dashmap::DashMap;
+    use crate::store::memory::MemoryStore;
     use std::sync::atomic::AtomicUsize;
     use tokio;
-
-    #[derive(Default, Clone)]
-    struct MemoryStore {
-        data: Arc<DashMap<String, Vec<u8>>>,
-    }
-
-    #[cfg_attr(not(feature = "single-threaded"), async_trait)]
-    #[cfg_attr(feature = "single-threaded", async_trait(?Send))]
-    impl Store for MemoryStore {
-        async fn init(&self) -> Result<()> {
-            Ok(())
-        }
-
-        async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
-            Ok(self.data.get(key).map(|v| v.clone()))
-        }
-
-        async fn set(&self, key: &str, value: Vec<u8>) -> Result<()> {
-            self.data.insert(key.to_owned(), value);
-            Ok(())
-        }
-
-        async fn remove(&self, key: &str) -> Result<()> {
-            self.data.remove(key);
-            Ok(())
-        }
-
-        async fn exists(&self, key: &str) -> Result<bool> {
-            Ok(self.data.contains_key(key))
-        }
-    }
 
     #[derive(Default, Clone)]
     struct CallbackCounter {
@@ -576,7 +543,7 @@ mod test {
         sync_kv.set(b"foo", b"bar");
         assert_eq!(sync_kv.get(b"foo"), Some(b"bar".to_vec()));
 
-        assert!(store.data.is_empty());
+        assert!(store.is_empty());
 
         // We should have received a dirty callback.
         assert_eq!(c.count(), 1);
@@ -599,7 +566,7 @@ mod test {
             sync_kv.set(b"foo", b"bar");
             assert_eq!(sync_kv.get(b"foo"), Some(b"bar".to_vec()));
 
-            assert!(store.data.is_empty());
+            assert!(store.is_empty());
 
             sync_kv.persist().await.unwrap();
         }
@@ -667,13 +634,13 @@ mod test {
         .unwrap();
         concurrent.set(b"foo", b"concurrent");
         concurrent.persist().await.unwrap();
-        let concurrent_bytes = store.data.get(storage_key).unwrap().clone();
+        let concurrent_bytes = store.get_bytes(storage_key).unwrap();
 
         writer.set(b"foo", b"writer");
         let err = writer.persist_if_unchanged().await.unwrap_err();
 
         assert!(err.to_string().contains("Write lease conflict"));
-        assert_eq!(*store.data.get(storage_key).unwrap(), concurrent_bytes);
+        assert_eq!(store.get_bytes(storage_key).unwrap(), concurrent_bytes);
         assert!(writer.dirty.load(Ordering::Relaxed));
     }
 


### PR DESCRIPTION
🍋: (drafted with an LLM, reviewed by me)

Two log-volume problems motivated this:

- Baseline: with `relay-git-sync` sweeping ~1300 docs each pass, the per-doc lifecycle lines (save-loop throttling transitions, snapshot load/persist) put out ~10k lines/hour at info, which makes live pod logs unreadable and swamps anything interesting.
- Incident: a wedged client (app stopped draining its socket while the OS kept ACKing) kept its outbound channel full for ~3 hours, and the per-message backpressure warn emitted **3.8M identical, contextless lines** - 98.5% of our log volume that day - while never naming the doc or user that would have identified the wedged client.

Three changes, all logging-only:

1. **Demote per-doc lifecycle chatter to debug**: save-loop `Throttling.`/`Done throttling.`/`Received dirty|cancellation while throttling.`, `Terminating loop`, and sync_kv `Loading snapshot`/`Loaded CBOR`/`Persisting CBOR snapshot`. (Same spirit as the earlier `Received signal`/`Persisting.` demotions.) These share the `relay::server` target with genuinely useful info lines like `Loading doc`, so they can't be separated with `EnvFilter` directives - span-scoped directives can only enable, not suppress.
2. **Backpressure warn: log transitions, not messages.** One warn when a connection's outbound channel first fills - now carrying `doc_id` and `user` - and one info on recovery with a count of messages dropped in between. The existing per-drop metric is unchanged. The identity on the transition line is exactly what an operator needs to find the wedged client.
3. **Context on the multi-client awareness warn**: `user`, the connection's `client_id`, and the update's client ids. On our deployment this immediately showed the warn is mostly clients relaying their full awareness maps on reconnect - the bare message had made it look mysterious for months.

We're running the same changes in production (rebased onto our v0.12.1-equivalent base) - the pod logs went from unreadable to quiet-but-informative.
