### PR TITLE
Connection lifecycle logs, long-wedge escalation, context on remaining warns

### DIFF
--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -58,6 +58,10 @@ const PING_EVERY: Duration = Duration::from_secs(20);
 /// would-be keepalive reap. Observe-only: the connection is never closed for
 /// this; the metric exists to measure whether enforcement would be safe.
 const PONG_TIMEOUT: Duration = Duration::from_secs(40);
+/// How often to re-warn while a connection's outbound channel stays full. The
+/// full/recovered transition warns cover the common case; this distinguishes a
+/// client that is wedged for hours from one that stalled briefly.
+const CHANNEL_FULL_REWARN: Duration = Duration::from_secs(300);
 
 #[derive(Clone, Debug)]
 pub struct AllowedHost {
@@ -1181,6 +1185,8 @@ async fn handle_socket_inner<S, T, E>(
     let awareness = guard.awareness();
     let sync_kv = guard.sync_kv();
     let (send, mut recv) = channel(1024);
+    let connected_at = std::time::Instant::now();
+    tracing::debug!(doc_id = %doc_id, user = ?user, "WebSocket connected");
 
     // Cancelled when the writer task exits (sink write failure) or when the
     // parent server token cancels. The read loop selects on it so the
@@ -1202,11 +1208,15 @@ async fn handle_socket_inner<S, T, E>(
     let metrics_clone = metrics.clone();
     let callback_doc_id = doc_id.clone();
     let callback_user = user.clone();
+    let log_user = user.clone();
     // A wedged client can stay full for hours; per-message warns have produced
     // millions of identical, contextless lines in one incident. Log the
-    // full/recovered transitions with identity, count drops in between.
+    // full/recovered transitions with identity, count drops in between, and
+    // re-warn periodically so a long wedge stays visible.
     let channel_full = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let dropped_while_full = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let full_since_ms = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let last_warn_ms = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let mut conn = DocConnection::new_with_expiration(
         awareness,
         authorization,
@@ -1220,6 +1230,11 @@ async fn handle_socket_inner<S, T, E>(
                             user = ?callback_user,
                             dropped = dropped_while_full
                                 .swap(0, std::sync::atomic::Ordering::Relaxed),
+                            full_secs = (connected_at.elapsed().as_millis() as u64)
+                                .saturating_sub(
+                                    full_since_ms.load(std::sync::atomic::Ordering::Relaxed),
+                                )
+                                / 1000,
                             "Outbound channel recovered; messages were dropped while full"
                         );
                     }
@@ -1235,12 +1250,32 @@ async fn handle_socket_inner<S, T, E>(
                     // A dropped update silently desyncs this client until it
                     // reconnects; the metric tracks how often that happens.
                     metrics_clone.record_websocket_send_failure("full");
-                    dropped_while_full.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let dropped =
+                        dropped_while_full.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    let now_ms = connected_at.elapsed().as_millis() as u64;
                     if !channel_full.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        full_since_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
+                        last_warn_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
                         tracing::warn!(
                             doc_id = %callback_doc_id,
                             user = ?callback_user,
                             "Outbound channel full; dropping messages until it recovers"
+                        );
+                    } else if now_ms
+                        .saturating_sub(last_warn_ms.load(std::sync::atomic::Ordering::Relaxed))
+                        >= CHANNEL_FULL_REWARN.as_millis() as u64
+                    {
+                        last_warn_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!(
+                            doc_id = %callback_doc_id,
+                            user = ?callback_user,
+                            dropped,
+                            full_secs = now_ms
+                                .saturating_sub(
+                                    full_since_ms.load(std::sync::atomic::Ordering::Relaxed),
+                                )
+                                / 1000,
+                            "Outbound channel still full; dropping messages"
                         );
                     }
                 }
@@ -1298,7 +1333,12 @@ async fn handle_socket_inner<S, T, E>(
                         continue;
                     }
                     msg => {
-                        tracing::warn!(?msg, "Received non-binary message");
+                        tracing::warn!(
+                            doc_id = %doc_id,
+                            user = ?log_user,
+                            ?msg,
+                            "Received non-binary message"
+                        );
                         continue;
                     }
                 };
@@ -1323,7 +1363,12 @@ async fn handle_socket_inner<S, T, E>(
                         break "token_expired";
                     }
                     Err(e) => {
-                        tracing::warn!(?e, "Error handling message");
+                        tracing::warn!(
+                            doc_id = %doc_id,
+                            user = ?log_user,
+                            ?e,
+                            "Error handling message"
+                        );
                     }
                 }
             }
@@ -1356,6 +1401,13 @@ async fn handle_socket_inner<S, T, E>(
     };
 
     metrics.record_websocket_close(close_reason);
+    tracing::info!(
+        doc_id = %doc_id,
+        user = ?log_user,
+        close_reason,
+        duration_secs = connected_at.elapsed().as_secs(),
+        "WebSocket disconnected"
+    );
 
     // Teardown is pure RAII: dropping the guard detaches this connection
     // from the doc's lifecycle actor, and if it was the last one, the

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -446,7 +446,7 @@ impl DocConnection {
                         subscriptions.len()
                     );
                 } else {
-                    tracing::warn!("Failed to acquire event subscriptions lock for subscribe");
+                    tracing::warn!(user = ?self.user, "Failed to acquire event subscriptions lock for subscribe");
                 }
                 Ok(None)
             }
@@ -461,7 +461,7 @@ impl DocConnection {
                         subscriptions.len()
                     );
                 } else {
-                    tracing::warn!("Failed to acquire event subscriptions lock for unsubscribe");
+                    tracing::warn!(user = ?self.user, "Failed to acquire event subscriptions lock for unsubscribe");
                 }
                 Ok(None)
             }
@@ -673,12 +673,12 @@ impl DocConnection {
             }
             Message::Subdocs(_) => {
                 // Server shouldn't receive Subdocs from clients
-                tracing::warn!("Client sent Subdocs message to server, ignoring");
+                tracing::warn!(user = ?self.user, "Client sent Subdocs message to server, ignoring");
                 Ok(None)
             }
             Message::Event(_event_data) => {
                 // Clients shouldn't send events to the server, but we'll just log and ignore
-                tracing::warn!("Client sent event message to server, ignoring");
+                tracing::warn!(user = ?self.user, "Client sent event message to server, ignoring");
                 Ok(None)
             }
             Message::Custom(tag, data) => {
@@ -694,7 +694,7 @@ impl DocConnection {
         let is_subscribed = if let Ok(subscriptions) = self.event_subscriptions.read() {
             subscriptions.contains(&event.event_type)
         } else {
-            tracing::warn!("Failed to acquire event subscriptions lock for send_event");
+            tracing::warn!(user = ?self.user, "Failed to acquire event subscriptions lock for send_event");
             return Ok(()); // Fail silently
         };
 


### PR DESCRIPTION
Three observability changes for diagnosing client-wedge incidents in pod logs:

1. **Connection lifecycle log.** `handle_socket_inner` previously logged nothing when a websocket ended - the close reason was computed but only fed to metrics. Now an info-level `WebSocket disconnected` reports `doc_id`, `user`, `close_reason`, and `duration_secs`, so wedged clients and reconnect loops are visible directly in the logs (a reconnect loop reads as rapid short-duration disconnects from one user). Connect is logged at debug to keep steady-state volume at one line per connection.

2. **Long-wedge escalation.** The full/recovered transition warns emit one line at the moment a channel fills - a client wedged for hours is silent after minute zero. While the channel stays full, re-warn every 5 minutes with the cumulative drop count and how long it has been full; the recovery line now also reports the total full duration.

3. **Context on the remaining contextless warns.** `Error handling message` and `Received non-binary message` get `doc_id`/`user` (the former fires per bad message, so it was the same defect class as the old backpressure warn); the subscription-lock and Subdocs/Event protocol warns in `doc_connection.rs` get `user`.

No behavior changes; `cargo test` passes. We are running the same changes in production.