### PR TITLE
Log large deletions with sender identity; doc_id on connection warns

### DIFF
--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -58,6 +58,10 @@ const PING_EVERY: Duration = Duration::from_secs(20);
 /// would-be keepalive reap. Observe-only: the connection is never closed for
 /// this; the metric exists to measure whether enforcement would be safe.
 const PONG_TIMEOUT: Duration = Duration::from_secs(40);
+/// How often to re-warn while a connection's outbound channel stays full. The
+/// full/recovered transition warns cover the common case; this distinguishes a
+/// client that is wedged for hours from one that stalled briefly.
+const CHANNEL_FULL_REWARN: Duration = Duration::from_secs(300);
 
 #[derive(Clone, Debug)]
 pub struct AllowedHost {
@@ -1181,6 +1185,8 @@ async fn handle_socket_inner<S, T, E>(
     let awareness = guard.awareness();
     let sync_kv = guard.sync_kv();
     let (send, mut recv) = channel(1024);
+    let connected_at = std::time::Instant::now();
+    tracing::debug!(doc_id = %doc_id, user = ?user, "WebSocket connected");
 
     // Cancelled when the writer task exits (sink write failure) or when the
     // parent server token cancels. The read loop selects on it so the
@@ -1202,11 +1208,15 @@ async fn handle_socket_inner<S, T, E>(
     let metrics_clone = metrics.clone();
     let callback_doc_id = doc_id.clone();
     let callback_user = user.clone();
+    let log_user = user.clone();
     // A wedged client can stay full for hours; per-message warns have produced
     // millions of identical, contextless lines in one incident. Log the
-    // full/recovered transitions with identity, count drops in between.
+    // full/recovered transitions with identity, count drops in between, and
+    // re-warn periodically so a long wedge stays visible.
     let channel_full = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let dropped_while_full = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let full_since_ms = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let last_warn_ms = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let mut conn = DocConnection::new_with_expiration(
         awareness,
         authorization,
@@ -1220,6 +1230,11 @@ async fn handle_socket_inner<S, T, E>(
                             user = ?callback_user,
                             dropped = dropped_while_full
                                 .swap(0, std::sync::atomic::Ordering::Relaxed),
+                            full_secs = (connected_at.elapsed().as_millis() as u64)
+                                .saturating_sub(
+                                    full_since_ms.load(std::sync::atomic::Ordering::Relaxed),
+                                )
+                                / 1000,
                             "Outbound channel recovered; messages were dropped while full"
                         );
                     }
@@ -1235,12 +1250,32 @@ async fn handle_socket_inner<S, T, E>(
                     // A dropped update silently desyncs this client until it
                     // reconnects; the metric tracks how often that happens.
                     metrics_clone.record_websocket_send_failure("full");
-                    dropped_while_full.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let dropped =
+                        dropped_while_full.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    let now_ms = connected_at.elapsed().as_millis() as u64;
                     if !channel_full.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        full_since_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
+                        last_warn_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
                         tracing::warn!(
                             doc_id = %callback_doc_id,
                             user = ?callback_user,
                             "Outbound channel full; dropping messages until it recovers"
+                        );
+                    } else if now_ms
+                        .saturating_sub(last_warn_ms.load(std::sync::atomic::Ordering::Relaxed))
+                        >= CHANNEL_FULL_REWARN.as_millis() as u64
+                    {
+                        last_warn_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!(
+                            doc_id = %callback_doc_id,
+                            user = ?callback_user,
+                            dropped,
+                            full_secs = now_ms
+                                .saturating_sub(
+                                    full_since_ms.load(std::sync::atomic::Ordering::Relaxed),
+                                )
+                                / 1000,
+                            "Outbound channel still full; dropping messages"
                         );
                     }
                 }
@@ -1298,7 +1333,12 @@ async fn handle_socket_inner<S, T, E>(
                         continue;
                     }
                     msg => {
-                        tracing::warn!(?msg, "Received non-binary message");
+                        tracing::warn!(
+                            doc_id = %doc_id,
+                            user = ?log_user,
+                            ?msg,
+                            "Received non-binary message"
+                        );
                         continue;
                     }
                 };
@@ -1323,7 +1363,12 @@ async fn handle_socket_inner<S, T, E>(
                         break "token_expired";
                     }
                     Err(e) => {
-                        tracing::warn!(?e, "Error handling message");
+                        tracing::warn!(
+                            doc_id = %doc_id,
+                            user = ?log_user,
+                            ?e,
+                            "Error handling message"
+                        );
                     }
                 }
             }
@@ -1356,6 +1401,13 @@ async fn handle_socket_inner<S, T, E>(
     };
 
     metrics.record_websocket_close(close_reason);
+    tracing::info!(
+        doc_id = %doc_id,
+        user = ?log_user,
+        close_reason,
+        duration_secs = connected_at.elapsed().as_secs(),
+        "WebSocket disconnected"
+    );
 
     // Teardown is pure RAII: dropping the guard detaches this connection
     // from the doc's lifecycle actor, and if it was the last one, the

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -1283,6 +1283,7 @@ async fn handle_socket_inner<S, T, E>(
         },
     );
     conn.set_sync_kv(sync_kv);
+    conn.set_doc_id(doc_id.clone());
     if let Some(user) = user {
         conn.set_user(user);
     }

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -36,6 +36,28 @@ type Callback = Arc<dyn Fn(&[u8]) + 'static + Send + Sync>;
 
 const SYNC_STATUS_MESSAGE: u8 = 102;
 
+/// An incoming update that grows the doc's delete set by at least this many
+/// clock units is logged. Clock units roughly correspond to characters for
+/// text content, so this catches section-or-larger deletions while ignoring
+/// ordinary editing. Growth is measured across the apply because SyncStep2
+/// always carries the sender's full historical delete set, which is almost
+/// entirely already applied.
+const LARGE_DELETION_CLOCK_SPAN: u32 = 200;
+
+/// Total deleted clock span per client in the doc's current delete set.
+fn deleted_spans_by_client<T: ReadTxn>(txn: &T) -> std::collections::HashMap<ClientID, u32> {
+    txn.snapshot()
+        .delete_set
+        .iter()
+        .map(|(client, ranges)| {
+            (
+                *client,
+                ranges.into_iter().map(|r| r.end - r.start).sum::<u32>(),
+            )
+        })
+        .collect()
+}
+
 pub struct DocConnection {
     awareness: Arc<RwLock<Awareness>>,
     #[allow(unused)] // acts as RAII guard
@@ -63,6 +85,9 @@ pub struct DocConnection {
     /// Authenticated user identity from the connection token.
     /// When set, the server will register new client_ids under this user in the "users" map.
     user: Option<String>,
+
+    /// Document ID, for log context only.
+    doc_id: Option<String>,
 }
 
 impl DocConnection {
@@ -211,6 +236,7 @@ impl DocConnection {
             expiration_time,
             sync_kv: None,
             user: None,
+            doc_id: None,
         }
     }
 
@@ -222,6 +248,43 @@ impl DocConnection {
     /// Set the authenticated user identity for server-driven PUD registration.
     pub fn set_user(&mut self, user: String) {
         self.user = Some(user);
+    }
+
+    /// Set the document ID for log context.
+    pub fn set_doc_id(&mut self, doc_id: String) {
+        self.doc_id = Some(doc_id);
+    }
+
+    /// Log when this connection's update grew the doc's delete set by
+    /// [LARGE_DELETION_CLOCK_SPAN] or more. The doc structurally records who
+    /// inserted content but not who deleted it, so the connection is the only
+    /// place a deletion can be attributed to a user.
+    fn log_large_deletion(
+        &self,
+        spans_before: &std::collections::HashMap<ClientID, u32>,
+        awareness: &Awareness,
+    ) {
+        let mut newly_deleted: Vec<(ClientID, u32)> =
+            deleted_spans_by_client(&awareness.doc().transact())
+                .into_iter()
+                .filter_map(|(client, span)| {
+                    let growth =
+                        span.saturating_sub(spans_before.get(&client).copied().unwrap_or(0));
+                    (growth > 0).then_some((client, growth))
+                })
+                .collect();
+        let deleted_clock_span: u32 = newly_deleted.iter().map(|(_, growth)| growth).sum();
+        if deleted_clock_span >= LARGE_DELETION_CLOCK_SPAN {
+            newly_deleted.sort_by_key(|(_, growth)| std::cmp::Reverse(*growth));
+            newly_deleted.truncate(10);
+            tracing::info!(
+                doc_id = ?self.doc_id,
+                user = ?self.user,
+                deleted_clock_span,
+                top_deleted_from = ?newly_deleted,
+                "Update applied a large deletion"
+            );
+        }
     }
 
     /// Snapshot the current state vector's client_ids (for before/after comparison).
@@ -375,10 +438,12 @@ impl DocConnection {
                     if can_write {
                         let mut awareness = a.write().unwrap();
                         let sv_before = self.snapshot_sv(&awareness);
+                        let ds_before = deleted_spans_by_client(&awareness.doc().transact());
                         let result =
                             protocol.handle_sync_step2(&mut awareness, Update::decode_v1(&update)?);
                         if result.is_ok() {
                             self.register_new_client_ids(&awareness, &sv_before);
+                            self.log_large_deletion(&ds_before, &awareness);
                         }
                         result
                     } else {
@@ -395,10 +460,12 @@ impl DocConnection {
                     if can_write {
                         let mut awareness = a.write().unwrap();
                         let sv_before = self.snapshot_sv(&awareness);
+                        let ds_before = deleted_spans_by_client(&awareness.doc().transact());
                         let result =
                             protocol.handle_update(&mut awareness, Update::decode_v1(&update)?);
                         if result.is_ok() {
                             self.register_new_client_ids(&awareness, &sv_before);
+                            self.log_large_deletion(&ds_before, &awareness);
                         }
                         result
                     } else {
@@ -421,7 +488,11 @@ impl DocConnection {
                     let client_id = update.clients.keys().next().unwrap();
                     self.client_id.get_or_init(|| *client_id);
                 } else {
-                    tracing::warn!(
+                    // Clients routinely relay the full awareness map on
+                    // reconnect; this is normal protocol behavior, not an
+                    // anomaly worth warning about.
+                    tracing::debug!(
+                        doc_id = ?self.doc_id,
                         user = ?self.user,
                         connection_client_id = ?self.client_id.get(),
                         update_client_ids = ?update.clients.keys().collect::<Vec<_>>(),
@@ -745,6 +816,42 @@ impl Drop for DocConnection {
 mod tests {
     use super::*;
     use crate::sync::{DefaultProtocol, EventMessage, Message, SyncMessage};
+
+    #[test]
+    fn test_deleted_spans_by_client_growth_measures_removed_text() {
+        use yrs::{Doc, GetString, Text};
+
+        let doc = Doc::new();
+        let client = doc.client_id();
+        let text = doc.get_or_insert_text("t");
+        {
+            let mut txn = doc.transact_mut();
+            text.insert(&mut txn, 0, &"x".repeat(500));
+        }
+        let before = deleted_spans_by_client(&doc.transact());
+        assert_eq!(before.get(&client), None);
+        {
+            let mut txn = doc.transact_mut();
+            text.remove_range(&mut txn, 0, 300);
+            assert_eq!(text.get_string(&txn).len(), 200);
+        }
+        let after = deleted_spans_by_client(&doc.transact());
+        assert_eq!(after.get(&client), Some(&300));
+
+        // Re-applying a full-state update (as SyncStep2 does) must not grow the spans.
+        {
+            let full_state = doc
+                .transact()
+                .encode_state_as_update_v1(&yrs::StateVector::default());
+            let mut txn = doc.transact_mut();
+            txn.apply_update(Update::decode_v1(&full_state).unwrap())
+                .unwrap();
+        }
+        assert_eq!(
+            deleted_spans_by_client(&doc.transact()).get(&client),
+            Some(&300)
+        );
+    }
 
     #[tokio::test]
     async fn test_query_subdocs_returns_snapshot_envelope() {

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -446,7 +446,7 @@ impl DocConnection {
                         subscriptions.len()
                     );
                 } else {
-                    tracing::warn!("Failed to acquire event subscriptions lock for subscribe");
+                    tracing::warn!(user = ?self.user, "Failed to acquire event subscriptions lock for subscribe");
                 }
                 Ok(None)
             }
@@ -461,7 +461,7 @@ impl DocConnection {
                         subscriptions.len()
                     );
                 } else {
-                    tracing::warn!("Failed to acquire event subscriptions lock for unsubscribe");
+                    tracing::warn!(user = ?self.user, "Failed to acquire event subscriptions lock for unsubscribe");
                 }
                 Ok(None)
             }
@@ -673,12 +673,12 @@ impl DocConnection {
             }
             Message::Subdocs(_) => {
                 // Server shouldn't receive Subdocs from clients
-                tracing::warn!("Client sent Subdocs message to server, ignoring");
+                tracing::warn!(user = ?self.user, "Client sent Subdocs message to server, ignoring");
                 Ok(None)
             }
             Message::Event(_event_data) => {
                 // Clients shouldn't send events to the server, but we'll just log and ignore
-                tracing::warn!("Client sent event message to server, ignoring");
+                tracing::warn!(user = ?self.user, "Client sent event message to server, ignoring");
                 Ok(None)
             }
             Message::Custom(tag, data) => {
@@ -694,7 +694,7 @@ impl DocConnection {
         let is_subscribed = if let Ok(subscriptions) = self.event_subscriptions.read() {
             subscriptions.contains(&event.event_type)
         } else {
-            tracing::warn!("Failed to acquire event subscriptions lock for send_event");
+            tracing::warn!(user = ?self.user, "Failed to acquire event subscriptions lock for send_event");
             return Ok(()); // Fail silently
         };
 


### PR DESCRIPTION
Builds on #18 (connection lifecycle logs).

The motivating incident involved content deletions we could not attribute to any client. The doc structurally records who *inserted* content (item client IDs + the PUD `users` map), but yjs delete sets carry no author - and the server clears the PUD `ds` arrays at compaction - so the connection that delivers a deletion is the only place it can be attributed to a user.

Three changes:

1. **Large-deletion audit log.** An incoming update (Update or SyncStep2 path) that grows the doc's delete set by >= 200 clock units logs at info with `doc_id`, `user`, the growth, and the top-10 client IDs whose content was deleted. Growth is measured across the apply (delete-set spans per client before vs. after) rather than from the update's raw delete set, because SyncStep2 always carries the sender's full historical delete set - measuring the raw update logged a false "large deletion" on every reconnect to any doc with history. Clock units roughly correspond to characters, so this catches section-or-larger deletions while ignoring ordinary editing.
2. **`DocConnection` learns its `doc_id`** (a setter alongside `set_user`), giving the deletion log and the awareness warn document context.
3. **The multi-client awareness warn is demoted to debug** (with full context retained). On our deployment clients routinely relay the full awareness map on reconnect (~100 warns/min across ~10 users, evenly distributed) - it's normal protocol behavior, not an anomaly.

The span-growth computation has a unit test (including the SyncStep2 re-apply case); `cargo test` passes. We run the same changes in production.